### PR TITLE
Do not use absolute url for esi-includes

### DIFF
--- a/Adapter/EsiCache.php
+++ b/Adapter/EsiCache.php
@@ -143,7 +143,7 @@ class EsiCache implements CacheInterface
             'parameters' => $keys
         );
 
-        return $this->router->generate('sonata_cache_esi', $parameters, true);
+        return $this->router->generate('sonata_cache_esi', $parameters, false);
     }
 
     /**


### PR DESCRIPTION
When your application (including varnish) sits behind a load balancer you have to configure symfony to use ports and hostname of that load balancer. But then the absolute url generated here will not work any more.

After changing this to relative Urls caching still works ...
