### PR TITLE
Fix composer dependencies between require and require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "doctrine/common": ">=2.1,<2.3",
         "symfony/routing": "2.0.*",
         "symfony/http-kernel": "2.0.*",
         "symfony/dependency-injection": "2.0.*",
@@ -25,10 +26,7 @@
         "symfony/framework-bundle": "2.0.*"
     },
     "require-dev": {
-        "doctrine/orm": "2.1.*"
-    },
-    "suggest": {
-        "doctrine/orm": ">=2.1.0"
+        "doctrine/orm": ">=2.1,<2.3"
     },
     "autoload": {
         "psr-0": { "Sonata\\CacheBundle": "" }


### PR DESCRIPTION
"doctrine/common" was being referenced by two different sources "symfony/framework-bundle" (require) and "dotrine/orm" (require-dev). Composer seems to have trouble matching dependencies from both require and require-dev so I enforced it in the "require" to fix the issue.
