### PR TITLE
Composer.json fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "dev-master"
+        "symfony/symfony": "2.1.*"
     },
     "suggest": {
         "doctrine/orm": ">=2.2.0"


### PR DESCRIPTION
Modified composer.json to depend on symfony 2.1.\* instead of dev-master, allowing people to set the version to RC1 without composer not being able to resolve dependencies.
