### PR TITLE
Solved MongoBinData Deprecated Exception

### DIFF
--- a/Adapter/MongoCache.php
+++ b/Adapter/MongoCache.php
@@ -90,7 +90,7 @@ class MongoCache implements CacheInterface
         $cacheElement = new CacheElement($keys, $data, $ttl, $contextualKeys);
 
         $keys = $cacheElement->getContextualKeys() + $cacheElement->getKeys();
-        $keys['_value']       = new \MongoBinData(serialize($cacheElement));
+        $keys['_value']       = new \MongoBinData(serialize($cacheElement), \MongoBinData::BYTE_ARRAY);
         $keys['_updated_at']  = $time;
         $keys['_timeout']     = $time + $cacheElement->getTtl();
 


### PR DESCRIPTION
Solved an issue caused by and Exception raised to a Deprecated use of the MongoBinData constructor.
The error message is:
Deprecated: MongoBinData::__construct() [<a href='mongobindata.--construct'>mongobindata.--construct</a>]: The default value for type will change to 0 in the future. Please pass in '2' explicitly. in [...]/vendor/bundles/Sonata/CacheBundle/Adapter/MongoCache.php line 93
