### PR TITLE
Declaring namespaces in the Symfony >=2.1 way

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -23,11 +23,7 @@ Update the ``autoload.php`` to add new namespaces:
 .. code-block:: php
 
     <?php
-    $loader->registerNamespaces(array(
-        'Sonata'                             => __DIR__,
-
-        // ... other declarations
-    ));
+    $loader->add('Sonata' => __DIR__);
 
 
 Configuration


### PR DESCRIPTION
I think the installation documentation should be updated.

Update the autoload.php to add new namespaces:

``` php
<?php
$loader->registerNamespaces(array(
    'Sonata'                             => __DIR__,

    // ... other declarations
));
```

This seems to be the Symfony 2.0 way of declaring namespaces. Now we should have

``` php
<?php
// intl
if (!function_exists('intl_get_error_code')) {
    $loader->add('Sonata', __DIR__);
    // … other declarations
}
```

My 2 cents

Guillaume
