### PR TITLE
use Doctrine ClassUtils to determine the class name

### DIFF
--- a/Invalidation/DoctrineORMListener.php
+++ b/Invalidation/DoctrineORMListener.php
@@ -16,6 +16,7 @@ use Sonata\CacheBundle\Invalidation\ModelCollectionIdentifiers;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Util\ClassUtils;
 
 class DoctrineORMListener implements EventSubscriber
 {
@@ -59,7 +60,7 @@ class DoctrineORMListener implements EventSubscriber
         }
 
         $parameters = array(
-            get_class($args->getEntity()) => $identifier
+            ClassUtils::getClass($args->getEntity()) => $identifier
         );
 
         foreach ($this->caches as $cache) {

--- a/Invalidation/DoctrinePHPCRODMListener.php
+++ b/Invalidation/DoctrinePHPCRODMListener.php
@@ -15,6 +15,7 @@ use Sonata\CacheBundle\Cache\CacheInterface;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\PHPCR\Event;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Common\Util\ClassUtils;
 
 class DoctrinePHPCRODMListener implements EventSubscriber
 {
@@ -58,7 +59,7 @@ class DoctrinePHPCRODMListener implements EventSubscriber
         }
 
         $parameters = array(
-            get_class($args->getDocument()) => $identifier
+            ClassUtils::getClass($args->getDocument()) => $identifier
         );
 
         foreach ($this->caches as $cache) {


### PR DESCRIPTION
we actually use `get_class()` in a few other places in this Bundle and I think it would be good to also make it possible to use `ClassUtils` on those places. however these are not Doctrine specific. so we might need to make this configurable or a callback.
