### PR TITLE
Add contextual cache to documentation (from PageBundle)

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -11,3 +11,4 @@ Reference Guide
    reference/introduction
    reference/installation
    reference/command_line
+   reference/contextual_cache

--- a/Resources/doc/reference/contextual_cache.rst
+++ b/Resources/doc/reference/contextual_cache.rst
@@ -1,0 +1,12 @@
+Contextual Cache
+================
+
+You can configure the ``Twig Recorder`` with the following configuration:
+
+.. code-block:: yaml
+
+    twig:
+        base_template_class: Sonata\CacheBundle\Twig\TwigTemplate13
+        base_template_class: Sonata\CacheBundle\Twig\TwigTemplate14
+
+// todo add more information

--- a/Twig/TwigTemplate13.php
+++ b/Twig/TwigTemplate13.php
@@ -16,7 +16,7 @@ use Sonata\CacheBundle\Invalidation\Recorder;
 abstract class TwigTemplate13 extends \Twig_Template
 {
     /**
-     * @var \Sonata\CacheBundle\Cache\Invalidation\Recorder
+     * @var \Sonata\CacheBundle\Invalidation\Recorder
      */
     protected static $recorder;
 

--- a/Twig/TwigTemplate14.php
+++ b/Twig/TwigTemplate14.php
@@ -16,7 +16,7 @@ use Sonata\CacheBundle\Invalidation\Recorder;
 abstract class TwigTemplate14 extends \Twig_Template
 {
     /**
-     * @var \Sonata\CacheBundle\Cache\Invalidation\Recorder
+     * @var \Sonata\CacheBundle\Invalidation\Recorder
      */
     protected static $recorder;
 


### PR DESCRIPTION
I've added `Contextual cache` part coming from `SonataPageBundle` and removed in PR https://github.com/sonata-project/SonataPageBundle/pull/252.

I've also fixed a wrong PHPDoc.
