### PR TITLE
Make cacheAction perform both a user and a system cache

### DIFF
--- a/Adapter/ApcCache.php
+++ b/Adapter/ApcCache.php
@@ -65,6 +65,7 @@ class ApcCache extends BaseApcCache
     {
         if ($this->token == $token) {
             apc_clear_cache('user');
+            apc_clear_cache();
 
             return new Response('ok', 200, array(
                 'Cache-Control'  => 'no-cache, must-revalidate',


### PR DESCRIPTION
I've updated `cacheAction()` method to make both `apc_clear_cache('user')` and `apc_clear_cache()` (system) cache types.
