### PR TITLE
Fixed ip detection and removed unused use statement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
+        "php-mock/php-mock": "^0.1.1 || ^1.0",
         "predis/predis": "^0.8",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- IP detection in SymfonyCache
```

## Subject

<!-- Describe your Pull Request content here -->
There was a mistake in the detection of the IP version based on the count of ".".
