### PR TITLE
Configured timeout to clear Symfony cache

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -170,6 +170,45 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
+                            ->arrayNode('timeout')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->arrayNode('RCV')
+                                        ->addDefaultsIfNotSet()
+                                        ->children()
+                                            ->integerNode('sec')
+                                                ->info('Timeout value specifying the amount of seconds for input operations')
+                                                ->defaultValue(2)
+                                            ->end()
+                                            ->integerNode('usec')
+                                                ->info('Timeout value specifying the amount of microseconds for input operations')
+                                                ->defaultValue(0)
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                    ->arrayNode('SND')
+                                        ->addDefaultsIfNotSet()
+                                        ->children()
+                                            ->integerNode('sec')
+                                                ->info(<<<'INFO'
+Timeout value specifying the amount of seconds that an output function
+blocks because flow control prevents data from being sent
+INFO
+                                                )
+                                                ->defaultValue(2)
+                                            ->end()
+                                            ->integerNode('usec')
+                                                ->info(<<<'INFO'
+Timeout value specifying the amount of microseconds that an output function
+blocks because flow control prevents data from being sent
+INFO
+                                                )
+                                                ->defaultValue(0)
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/SonataCacheExtension.php
+++ b/DependencyInjection/SonataCacheExtension.php
@@ -212,6 +212,7 @@ class SonataCacheExtension extends Extension
                 ->replaceArgument(4, $config['caches']['symfony']['php_cache_enabled'])
                 ->replaceArgument(5, $config['caches']['symfony']['types'])
                 ->replaceArgument(6, $this->configureServers($config['caches']['symfony']['servers']))
+                ->replaceArgument(7, $config['caches']['symfony']['timeout'])
             ;
         } else {
             $container->removeDefinition('sonata.cache.symfony');

--- a/Resources/config/cache.xml
+++ b/Resources/config/cache.xml
@@ -60,6 +60,7 @@
             <argument/>
             <argument/>
             <argument type="collection"/>
+            <argument/>
         </service>
         <service id="sonata.cache.invalidation.simple" class="Sonata\CacheBundle\Invalidation\SimpleCacheInvalidation">
             <argument type="service" id="logger"/>

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -78,7 +78,10 @@ To use the ``CacheBundle``, add the following lines to your application configur
                 php_cache_enabled: true # Optional (default: false), clear APC or PHP OPcache
                 types: [mytype1, mycustomtype2] # Optional, you can restrict allowed cache types
                 servers:
-                    - { domain: kooqit.local, ip: 127.0.0.1, port: 80}
+                    - { domain: kooqit.local, ip: 127.0.0.1, port: 80 }
+                timeout:
+                    RCV: { sec: 2, usec: 0 }
+                    SND: { sec: 2, usec: 0 }
 
 For APC and Symfony caches, you can specify a basic parameter for servers definition (useful to clear cache for staging area behind this kind of protection)
 

--- a/Tests/Adapter/SymfonyCacheTest.php
+++ b/Tests/Adapter/SymfonyCacheTest.php
@@ -45,7 +45,16 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
         $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
         $this->filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
 
-        $this->cache = new SymfonyCache($this->router, $this->filesystem, '/cache/dir', 'token', false, array('all', 'translations'), array());
+        $this->cache = new SymfonyCache(
+            $this->router,
+            $this->filesystem,
+            '/cache/dir',
+            'token',
+            false,
+            array('all', 'translations'),
+            array(),
+            array()
+        );
     }
 
     /**
@@ -126,7 +135,8 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
             array('all', 'translations'),
             array(
                 array('ip' => 'wrong ip'),
-            )
+            ),
+            array()
         );
 
         $this->setExpectedException('\InvalidArgumentException', '"wrong ip" is not a valid ip address');
@@ -150,6 +160,10 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
             array('all', 'translations'),
             array(
                 array('ip' => '213.186.35.9', 'domain' => 'www.example.com', 'basic' => false, 'port' => 80),
+            ),
+            array(
+                'RCV' => array('sec' => 2, 'usec' => 0),
+                'SND' => array('sec' => 2, 'usec' => 0),
             )
         );
 
@@ -204,6 +218,10 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
             array('all', 'translations'),
             array(
                 array('ip' => '2001:41d0:1:209:FF:FF:FF:FF', 'domain' => 'www.example.com', 'basic' => false, 'port' => 80),
+            ),
+            array(
+                'RCV' => array('sec' => 2, 'usec' => 0),
+                'SND' => array('sec' => 2, 'usec' => 0),
             )
         );
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -24,11 +24,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      */
     public function testApcDefaultTimeout()
     {
-        $expected = array(
-            'RCV' => array(),
-            'SND' => array(),
-        );
-
         $configs = array(array(
             'caches' => array(
                 'apc' => array(
@@ -41,7 +36,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $config = $this->process($configs);
 
         $this->assertArrayHasKey('timeout', $config['caches']['apc']);
-        $this->assertEquals($expected, $config['caches']['apc']['timeout']);
+        $this->assertSame(
+            array(
+                'RCV' => array(),
+                'SND' => array(),
+            ),
+            $config['caches']['apc']['timeout']
+        );
     }
 
     /**
@@ -67,7 +68,59 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $config = $this->process($configs);
 
         $this->assertArrayHasKey('timeout', $config['caches']['apc']);
-        $this->assertEquals($expected, $config['caches']['apc']['timeout']);
+        $this->assertSame($expected, $config['caches']['apc']['timeout']);
+    }
+
+    /**
+     * Asserts Symfony has default timeout values.
+     */
+    public function testSymfonyDefaultTimeout()
+    {
+        $configs = array(array(
+            'caches' => array(
+                'symfony' => array(
+                    'token' => '',
+                    'types' => array('all'),
+                ),
+            ),
+        ));
+
+        $config = $this->process($configs);
+
+        $this->assertArrayHasKey('timeout', $config['caches']['symfony']);
+        $this->assertSame(
+            array(
+                'RCV' => array('sec' => 2, 'usec' => 0),
+                'SND' => array('sec' => 2, 'usec' => 0),
+            ),
+            $config['caches']['symfony']['timeout']
+        );
+    }
+
+    /**
+     * Asserts Symfony timeout has custom values.
+     */
+    public function testSymfonyCustomTimeout()
+    {
+        $expected = array(
+            'RCV' => array('sec' => 10, 'usec' => 0),
+            'SND' => array('sec' => 18, 'usec' => 12),
+        );
+
+        $configs = array(array(
+            'caches' => array(
+                'symfony' => array(
+                    'token' => '',
+                    'types' => array('all'),
+                    'timeout' => $expected,
+                ),
+            ),
+        ));
+
+        $config = $this->process($configs);
+
+        $this->assertArrayHasKey('timeout', $config['caches']['symfony']);
+        $this->assertSame($expected, $config['caches']['symfony']['timeout']);
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added the possibility to configure the timeout to clear the Symfony cache.
```

## Subject

<!-- Describe your Pull Request content here -->
The timeout to clear the Symfony cache was hard-coded (2 seconds), I add some configuration to be able to tweak it as you want.
