### PR TITLE
Fixed variable conflict when multiple Varnish servers are configured

### DIFF
--- a/Adapter/VarnishCache.php
+++ b/Adapter/VarnishCache.php
@@ -180,10 +180,13 @@ class VarnishCache implements CacheAdapterInterface
     protected function runCommand($command, $expression)
     {
         $return = true;
-        foreach ($this->servers as $server) {
-            $command = str_replace(array('{{ COMMAND }}', '{{ EXPRESSION }}'), array($command, $expression), $server);
 
-            $process = new Process($command);
+        foreach ($this->servers as $server) {
+            $process = new Process(str_replace(
+                array('{{ COMMAND }}', '{{ EXPRESSION }}'),
+                array($command, $expression),
+                $server
+            ));
 
             if ($process->run() == 0) {
                 continue;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bug fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed variable conflict when multiple Varnish servers are configured
```

## Subject

<!-- Describe your Pull Request content here -->
When multiple Varnish servers are configured, the `$command` argument is lost in the `runCommand` method.
