### PR TITLE
Drop old versions

### DIFF
--- a/Adapter/SymfonyCache.php
+++ b/Adapter/SymfonyCache.php
@@ -63,8 +63,6 @@ class SymfonyCache implements CacheAdapterInterface
     /**
      * Constructor.
      *
-     * NEXT_MAJOR: make the timeouts argument mandatory
-     *
      * @param RouterInterface $router              A router instance
      * @param Filesystem      $filesystem          A Symfony Filesystem component instance
      * @param string          $cacheDir            A Symfony cache directory
@@ -74,17 +72,8 @@ class SymfonyCache implements CacheAdapterInterface
      * @param array           $servers             An array of servers
      * @param array           $timeouts            An array of timeout options
      */
-    public function __construct(RouterInterface $router, Filesystem $filesystem, $cacheDir, $token, $phpCodeCacheEnabled, array $types, array $servers, array $timeouts = array())
+    public function __construct(RouterInterface $router, Filesystem $filesystem, $cacheDir, $token, $phpCodeCacheEnabled, array $types, array $servers, array $timeouts)
     {
-        if (!$timeouts) {
-            @trigger_error('The "timeouts" argument is available since 3.x and will become mandatory in 4.0, please provide it.', E_USER_DEPRECATED);
-
-            $timeouts = array(
-                'RCV' => array('sec' => 2, 'usec' => 0),
-                'SND' => array('sec' => 2, 'usec' => 0),
-            );
-        }
-
         $this->router = $router;
         $this->filesystem = $filesystem;
         $this->cacheDir = $cacheDir;

--- a/Tests/Adapter/SymfonyCacheTest.php
+++ b/Tests/Adapter/SymfonyCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CacheBundle\Tests\Adapter;
 
+use phpmock\MockBuilder;
 use Sonata\CacheBundle\Adapter\SymfonyCache;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\RouterInterface;
@@ -149,8 +150,6 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testFlushWithIPv4()
     {
-        $mockBuilderClass = $this->getMockBuilderClass();
-
         $cache = new SymfonyCache(
             $this->router,
             $this->filesystem,
@@ -172,7 +171,7 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
 
         $mocks = array();
 
-        $builder = new $mockBuilderClass();
+        $builder = new MockBuilder();
         $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
             ->setName('socket_create')
             ->setFunction(function () use ($that) {
@@ -184,7 +183,7 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
         $mocks[] = $mock;
 
         foreach (array('socket_set_option', 'socket_connect', 'socket_write', 'socket_read') as $function) {
-            $builder = new $mockBuilderClass();
+            $builder = new MockBuilder();
             $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
                 ->setName($function)
                 ->setFunction(function () {
@@ -207,8 +206,6 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testFlushWithIPv6()
     {
-        $mockBuilderClass = $this->getMockBuilderClass();
-
         $cache = new SymfonyCache(
             $this->router,
             $this->filesystem,
@@ -230,7 +227,7 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
 
         $mocks = array();
 
-        $builder = new $mockBuilderClass();
+        $builder = new MockBuilder();
         $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
             ->setName('socket_create')
             ->setFunction(function () use ($that) {
@@ -242,7 +239,7 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
         $mocks[] = $mock;
 
         foreach (array('socket_set_option', 'socket_connect', 'socket_write', 'socket_read') as $function) {
-            $builder = new $mockBuilderClass();
+            $builder = new MockBuilder();
             $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
                 ->setName($function)
                 ->setFunction(function () {
@@ -258,22 +255,5 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
         foreach ($mocks as $mock) {
             $mock->disable();
         }
-    }
-
-    /**
-     * Gets the mock builder class according to the lib version (ie the PHP version).
-     * NEXT_MAJOR: while dropping old versions of php, restrict the library to version ^1.0 and simplify this.
-     *
-     * @return string
-     */
-    private function getMockBuilderClass()
-    {
-        if (class_exists('phpmock\MockBuilder')) {
-            return 'phpmock\MockBuilder';
-        } elseif (class_exists('malkusch\phpmock\MockBuilder')) {
-            return 'malkusch\phpmock\MockBuilder';
-        }
-
-        $this->fail('Unable to find the MockBuilder class to mock built-in PHP functions');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
-        "php-mock/php-mock": "^0.1.1 || ^1.0",
+        "php-mock/php-mock": "^1.0",
         "predis/predis": "^0.8",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "symfony/config": "^2.2 || ^3.0",
         "symfony/filesystem": "^2.2 || ^3.0",
         "symfony/http-foundation": "^2.2 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/config": "^2.2 || ^3.0",
-        "symfony/filesystem": "^2.2 || ^3.0",
-        "symfony/http-foundation": "^2.2 || ^3.0",
-        "symfony/routing": "^2.2 || ^3.0",
-        "symfony/security": "^2.2 || ^3.0",
-        "symfony/process": "^2.2 || ^3.0",
+        "symfony/config": "^2.8 || ^3.0",
+        "symfony/filesystem": "^2.8 || ^3.0",
+        "symfony/http-foundation": "^2.8 || ^3.0",
+        "symfony/routing": "^2.8 || ^3.0",
+        "symfony/security": "^2.8 || ^3.0",
+        "symfony/process": "^2.8 || ^3.0",
         "sonata-project/cache": "^1.0.3"
     },
     "require-dev": {
@@ -31,7 +31,7 @@
         "php-mock/php-mock": "^0.1.1 || ^1.0",
         "predis/predis": "^0.8",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "ORM support",


### PR DESCRIPTION
I am targetting this branch, because bumping minor versions of dependencies is considered major.

Closes #120 

## Changelog
```markdown
### Removed
- PHP 5.3 through 5.5 support was removed
- Symfony 2.2 through 2.7 support was removed
```
## Subject

This prepares the next major release.
