### PR TITLE
Handle deprecations with trigger_error()

### DIFF
--- a/Adapter/MemcachedCache.php
+++ b/Adapter/MemcachedCache.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Adapter;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\MemcachedCache class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Adapter\Cache\MemcachedCache instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use \Sonata\Cache\Adapter\Cache\MemcachedCache
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Adapter\Cache\MemcachedCache instead.
  */
 class MemcachedCache extends \Sonata\Cache\Adapter\Cache\MemcachedCache
 {

--- a/Adapter/MongoCache.php
+++ b/Adapter/MongoCache.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Adapter;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\MongoCache class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Adapter\Cache\MongoCache instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use \Sonata\Cache\Adapter\Cache\MongoCache
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Adapter\Cache\MongoCache instead.
  */
 class MongoCache extends \Sonata\Cache\Adapter\Cache\MongoCache
 {

--- a/Adapter/NoopCache.php
+++ b/Adapter/NoopCache.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Adapter;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\NoopCache class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Adapter\Cache\NoopCache instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use \Sonata\Cache\Adapter\Cache\NoopCache
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Adapter\Cache\NoopCache instead.
  */
 class NoopCache extends \Sonata\Cache\Adapter\Cache\NoopCache
 {

--- a/Adapter/PRedisCache.php
+++ b/Adapter/PRedisCache.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Adapter;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\PRedisCache class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Adapter\Cache\PRedisCache instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use \Sonata\Cache\Adapter\Cache\PRedisCache
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Adapter\Cache\PRedisCache instead.
  */
 class PRedisCache extends \Sonata\Cache\Adapter\Cache\PRedisCache
 {

--- a/Cache/CacheInterface.php
+++ b/Cache/CacheInterface.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Cache;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\CacheInterface class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\CacheInterface instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\CacheAdapterInterface
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\CacheInterface instead.
  */
 interface CacheInterface extends \Sonata\Cache\CacheAdapterInterface
 {

--- a/Cache/CacheManager.php
+++ b/Cache/CacheManager.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Cache;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\CacheManager class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\CacheManager instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\CacheManager
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\CacheManager instead.
  */
 class CacheManager extends \Sonata\Cache\CacheManager
 {

--- a/Cache/CacheManagerInterface.php
+++ b/Cache/CacheManagerInterface.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Cache;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\CacheManagerInterface class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\CacheManagerInterface instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\CacheManagerInterface
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\CacheManagerInterface instead.
  */
 interface CacheManagerInterface extends \Sonata\Cache\CacheManagerInterface
 {

--- a/Invalidation/DoctrineORMListener.php
+++ b/Invalidation/DoctrineORMListener.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Invalidation;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\DoctrineORMListener class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Invalidation\DoctrineORMListener instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\Invalidation\DoctrineORMListener
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Invalidation\DoctrineORMListener instead.
  */
 class DoctrineORMListener extends \Sonata\Cache\Invalidation\DoctrineORMListener
 {

--- a/Invalidation/DoctrinePHPCRODMListener.php
+++ b/Invalidation/DoctrinePHPCRODMListener.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Invalidation;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\DoctrinePHPCRODMListener class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Invalidation\DoctrinePHPCRODMListener instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\Invalidation\DoctrinePHPCRODMListener
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Invalidation\DoctrinePHPCRODMListener instead.
  */
 class DoctrinePHPCRODMListener extends \Sonata\Cache\Invalidation\DoctrinePHPCRODMListener
 {

--- a/Invalidation/InvalidationInterface.php
+++ b/Invalidation/InvalidationInterface.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Invalidation;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\InvalidationInterface class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Invalidation\InvalidationInterface instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\Invalidation\InvalidationInterface
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Invalidation\InvalidationInterface instead.
  */
 interface InvalidationInterface extends \Sonata\Cache\Invalidation\InvalidationInterface
 {

--- a/Invalidation/ModelCollectionIdentifiers.php
+++ b/Invalidation/ModelCollectionIdentifiers.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Invalidation;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\ModelCollectionIdentifiers class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Invalidation\ModelCollectionIdentifiers instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\Invalidation\ModelCollectionIdentifiers
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Invalidation\ModelCollectionIdentifiers instead.
  */
 class ModelCollectionIdentifiers extends \Sonata\Cache\Invalidation\ModelCollectionIdentifiers
 {

--- a/Invalidation/Recorder.php
+++ b/Invalidation/Recorder.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Invalidation;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\Recorder class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Invalidation\Recorder instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\Invalidation\Recorder
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Invalidation\Recorder instead.
  */
 class Recorder extends \Sonata\Cache\Invalidation\Recorder
 {

--- a/Invalidation/SimpleCacheInvalidation.php
+++ b/Invalidation/SimpleCacheInvalidation.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\CacheBundle\Invalidation;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\SimpleCacheInvalidation class is deprecated since version 2.4 and will be removed in 3.0.'
+    .' Use Sonata\Cache\Invalidation\SimpleCacheInvalidation instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated use Sonata\Cache\Invalidation\SimpleCacheInvalidation
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0. Use Sonata\Cache\Invalidation\SimpleCacheInvalidation instead.
  */
 class SimpleCacheInvalidation extends \Sonata\Cache\Invalidation\SimpleCacheInvalidation
 {

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,24 @@
 UPGRADE 2.x
 ===========
 
+### Deprecated
+
+| deprecated class | recommended class |
+|-------------------------|-----------------------------|
+| `Sonata\CacheBundle\Invalidation\SimpleCacheInvalidation` | `Sonata\Cache\Invalidation\SimpleCacheInvalidation` |
+| `Sonata\CacheBundle\Invalidation\Recorder` | `Sonata\Cache\Invalidation\Recorder` |
+| `Sonata\CacheBundle\Invalidation\ModelCollectionIdentifiers` | `Sonata\Cache\Invalidation\ModelCollectionIdentifiers` |
+| `Sonata\CacheBundle\Invalidation\InvalidationInterface` | `Sonata\Cache\Invalidation\InvalidationInterface` |
+| `Sonata\CacheBundle\Invalidation\DoctrinePHPCRODMListener` | `Sonata\Cache\Invalidation\DoctrinePHPCRODMListener` |
+| `Sonata\CacheBundle\Invalidation\DoctrineORMListener` | `Sonata\Cache\Invalidation\DoctrineORMListener` |
+| `Sonata\CacheBundle\Cache\CacheManager` | `Sonata\Cache\CacheManager` |
+| `Sonata\CacheBundle\Cache\CacheManagerInterface` | `Sonata\Cache\CacheManagerInterface` |
+| `Sonata\CacheBundle\Cache\CacheInterface` | `Sonata\Cache\CacheInterface` |
+| `Sonata\CacheBundle\Adapter\MemcachedCache` | `Sonata\Cache\Adapter\Cache\MemcachedCache` |
+| `Sonata\CacheBundle\Adapter\MongoCache` | `Sonata\Cache\Adapter\Cache\MongoCache` |
+| `Sonata\CacheBundle\Adapter\NoopCache` | `Sonata\Cache\Adapter\Cache\NoopCache` |
+| `Sonata\CacheBundle\Adapter\PRedisCache` | `Sonata\Cache\Adapter\Cache\PRedisCache` |
+
 ### Tests
 
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC and introduced already introduced deprecations.

As per definition, i mark this PR as `minor`!
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `Sonata\CacheBundle\Invalidation\SimpleCacheInvalidation`, use `Sonata\Cache\Invalidation\SimpleCacheInvalidation` instead.
- `Sonata\CacheBundle\Invalidation\Recorder`, use `Sonata\Cache\Invalidation\Recorder` instead.
- `Sonata\CacheBundle\Invalidation\ModelCollectionIdentifiers`, use `Sonata\Cache\Invalidation\ModelCollectionIdentifiers` instead.
- `Sonata\CacheBundle\Invalidation\InvalidationInterface`, use `Sonata\Cache\Invalidation\InvalidationInterface` instead.
- `Sonata\CacheBundle\Invalidation\DoctrinePHPCRODMListener`, use `Sonata\Cache\Invalidation\DoctrinePHPCRODMListener` instead.
- `Sonata\CacheBundle\Invalidation\DoctrineORMListener`, use `Sonata\Cache\Invalidation\DoctrineORMListener` instead.
- `Sonata\CacheBundle\Cache\CacheManager`, use `Sonata\Cache\CacheManager` instead.
- `Sonata\CacheBundle\Cache\CacheManagerInterface`, use `Sonata\Cache\CacheManagerInterface` instead.
- `Sonata\CacheBundle\Cache\CacheInterface`, use `Sonata\Cache\CacheInterface` instead.
- `Sonata\CacheBundle\Adapter\MemcachedCache`, use `Sonata\Cache\Adapter\Cache\MemcachedCache` instead.
- `Sonata\CacheBundle\Adapter\MongoCache`, use `Sonata\Cache\Adapter\Cache\MongoCache` instead.
- `Sonata\CacheBundle\Adapter\NoopCache`, use `Sonata\Cache\Adapter\Cache\NoopCache` instead.
- `Sonata\CacheBundle\Adapter\PRedisCache`, use `Sonata\Cache\Adapter\Cache\PRedisCache` instead.
```

## Subject

<!-- Describe your Pull Request content here -->

Deprecations are not new, but were not handeled with `trigger_error`