### PR TITLE
Add password to Predis cache configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -111,6 +111,7 @@ class Configuration implements ConfigurationInterface
                                         ->integerNode('port')->defaultValue(6379)->end()
                                         ->scalarNode('host')->defaultValue('localhost')->end()
                                         ->integerNode('database')->isRequired()->end()
+                                        ->integerNode('password')->defaultValue(null)->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -256,6 +256,7 @@ INFO
                                         ->integerNode('port')->defaultValue(6379)->end()
                                         ->scalarNode('host')->defaultValue('localhost')->end()
                                         ->integerNode('database')->isRequired()->end()
+                                        ->scalarNode('password')->defaultValue(null)->end()
                                     ->end()
                                 ->end()
                             ->end()


### PR DESCRIPTION
Adding the password to the Predis configuration, so that you may connect to a password protected Redis instance.

I am targeting this branch, because if you have a password on your redis instance, you will not be able to use redis as a cache option without this configuration option.

## Changelog

```markdown
### Added
- Adding the `password` key to the Predis configuration, so that you may connect to a password protected Redis instance.
```

## To do
- [x] Update the tests
- [x] Update the documentation
- [ ] Add an upgrade note

## Subject
Adding the `password` key to the Predis configuration, so that you may connect to a password protected Redis instance.
