### PR TITLE
Added password option to Predis in configuration.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -111,6 +111,7 @@ class Configuration implements ConfigurationInterface
                                         ->integerNode('port')->defaultValue(6379)->end()
                                         ->scalarNode('host')->defaultValue('localhost')->end()
                                         ->integerNode('database')->isRequired()->end()
+                                        ->scalarNode('password')->defaultValue(null)->end()
                                     ->end()
                                 ->end()
                             ->end()


### PR DESCRIPTION
I am targeting this branch, because it does not break anything, and adds functionality for those needing secure Redis instances through Predis.

## Changelog

```markdown
### Added
- Added password configuration option under Predis cache configuration.
```

## Subject
Some users might be using a password protected Redis instance. This modification allows for the use of a password that is sent directly to Predis from the Sonata Cache configuration.  It is an optional field.