### PR TITLE
Remove support for PHP <7.1

### DIFF
--- a/Adapter/ApcCache.php
+++ b/Adapter/ApcCache.php
@@ -57,7 +57,7 @@ class ApcCache extends BaseApcCache
     public function cacheAction($token)
     {
         if ($this->token == $token) {
-            if (version_compare(PHP_VERSION, '5.5.0', '>=') && function_exists('opcache_reset')) {
+            if (function_exists('opcache_reset')) {
                 opcache_reset();
             }
 

--- a/Adapter/ApcCache.php
+++ b/Adapter/ApcCache.php
@@ -61,9 +61,8 @@ class ApcCache extends BaseApcCache
                 opcache_reset();
             }
 
-            if (extension_loaded('apc') && ini_get('apc.enabled')) {
-                apc_clear_cache('user');
-                apc_clear_cache();
+            if (extension_loaded('apcu') && ini_get('apcu.enabled')) {
+                apcu_clear_cache();
             }
 
             return new Response('ok', 200, [

--- a/Adapter/SymfonyCache.php
+++ b/Adapter/SymfonyCache.php
@@ -69,7 +69,7 @@ class SymfonyCache implements CacheAdapterInterface
      * @param Filesystem      $filesystem          A Symfony Filesystem component instance
      * @param string          $cacheDir            A Symfony cache directory
      * @param string          $token               A token to clear the related cache
-     * @param bool            $phpCodeCacheEnabled If true, will clear APC or PHP OPcache code cache
+     * @param bool            $phpCodeCacheEnabled If true, will clear OPcache code cache
      * @param array           $types               A cache types array
      * @param array           $servers             An array of servers
      * @param array           $timeouts            An array of timeout options
@@ -247,7 +247,7 @@ class SymfonyCache implements CacheAdapterInterface
     }
 
     /**
-     * Clears code cache with PHP OPcache or APC.
+     * Clears code cache with PHP OPcache.
      */
     protected function clearPHPCodeCache()
     {
@@ -257,8 +257,6 @@ class SymfonyCache implements CacheAdapterInterface
 
         if (function_exists('opcache_reset')) {
             opcache_reset();
-        } elseif (function_exists('apc_fetch')) {
-            apc_clear_cache();
         }
     }
 }

--- a/Adapter/SymfonyCache.php
+++ b/Adapter/SymfonyCache.php
@@ -247,10 +247,7 @@ class SymfonyCache implements CacheAdapterInterface
     }
 
     /**
-     * Clears code cache with:.
-     *
-     * PHP < 5.5.0: APC
-     * PHP >= 5.5.0: PHP OPcache
+     * Clears code cache with PHP OPcache or APC.
      */
     protected function clearPHPCodeCache()
     {
@@ -258,7 +255,7 @@ class SymfonyCache implements CacheAdapterInterface
             return;
         }
 
-        if (version_compare(PHP_VERSION, '5.5.0', '>=') && function_exists('opcache_reset')) {
+        if (function_exists('opcache_reset')) {
             opcache_reset();
         } elseif (function_exists('apc_fetch')) {
             apc_clear_cache();

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -75,7 +75,7 @@ To use the ``CacheBundle``, add the following lines to your application configur
 
             symfony:
                 token: s3cur3 # token used to clear the related cache
-                php_cache_enabled: true # Optional (default: false), clear APC or PHP OPcache
+                php_cache_enabled: true # Optional (default: false), clear OPcache
                 types: [mytype1, mycustomtype2] # Optional, you can restrict allowed cache types
                 servers:
                     - { domain: kooqit.local, ip: 127.0.0.1, port: 80 }

--- a/Tests/Adapter/ApcCacheTest.php
+++ b/Tests/Adapter/ApcCacheTest.php
@@ -27,12 +27,12 @@ class ApcCacheTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (!function_exists('apc_store')) {
+        if (!function_exists('apcu_store')) {
             $this->markTestSkipped('APC is not installed');
         }
 
-        if (ini_get('apc.enable_cli') == 0) {
-            $this->markTestSkipped('APC is not enabled in cli, please add apc.enable_cli=On into the apc.ini file');
+        if (ini_get('apcu.enable_cli') == 0) {
+            $this->markTestSkipped('APC is not enabled in cli, please add apcu.enable_cli=On into the apcu.ini file');
         }
 
         $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/orm": "ORM support",
         "doctrine/phpcr-bundle": "PHPCR ODM support",
         "doctrine/phpcr-odm": "PHPCR ODM support",
-        "ext-apc": "Caching with ext/apc",
+        "ext-apcu": "Caching with ext/apcu",
         "ext-memcached": "Caching with ext/memcached",
         "predis/predis": "Install redis php"
     },


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for PHP <7.1
```

## Subject

This PR drops support for PHP <7.1, as listed in https://github.com/sonata-project/dev-kit/issues/216