### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "symfony/config": "^2.2 || ^3.0",
-        "symfony/filesystem": "^2.2 || ^3.0",
-        "symfony/http-foundation": "^2.2 || ^3.0",
-        "symfony/routing": "^2.2 || ^3.0",
-        "symfony/security": "^2.2 || ^3.0",
-        "symfony/process": "^2.2 || ^3.0",
+        "php": "^7.1",
+        "symfony/config": "^2.8 || ^3.2",
+        "symfony/filesystem": "^2.8 || ^3.2",
+        "symfony/http-foundation": "^2.8 || ^3.2",
+        "symfony/routing": "^2.8 || ^3.2",
+        "symfony/security": "^2.8 || ^3.2",
+        "symfony/process": "^2.8 || ^3.2",
         "sonata-project/cache": "^1.0.3"
     },
     "require-dev": {
@@ -31,7 +31,7 @@
         "php-mock/php-mock": "^0.1.1 || ^1.0",
         "predis/predis": "^0.8 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "ORM support",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
