### PR TITLE
Cache2 support

### DIFF
--- a/Adapter/SsiCache.php
+++ b/Adapter/SsiCache.php
@@ -13,6 +13,7 @@ namespace Sonata\CacheBundle\Adapter;
 
 use Sonata\Cache\CacheAdapterInterface;
 use Sonata\Cache\CacheElement;
+use Sonata\Cache\CacheElementInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
@@ -48,7 +49,7 @@ class SsiCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function flushAll()
+    public function flushAll(): bool
     {
         return true; // nothing to flush
     }
@@ -56,7 +57,7 @@ class SsiCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function flush(array $keys = [])
+    public function flush(array $keys = []): bool
     {
         return true; // still nothing to flush ...
     }
@@ -64,7 +65,7 @@ class SsiCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function has(array $keys)
+    public function has(array $keys): bool
     {
         return true;
     }
@@ -72,7 +73,7 @@ class SsiCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function get(array $keys)
+    public function get(array $keys): CacheElementInterface
     {
         if (!isset($keys['controller'])) {
             throw new \RuntimeException('Please define a controller key');
@@ -90,7 +91,7 @@ class SsiCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function set(array $keys, $data, $ttl = CacheElement::DAY, array $contextualKeys = [])
+    public function set(array $keys, $data, int $ttl = CacheElement::DAY, array $contextualKeys = []): CacheElementInterface
     {
         return new CacheElement($keys, $data, $ttl, $contextualKeys);
     }
@@ -124,7 +125,7 @@ class SsiCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function isContextual()
+    public function isContextual(): bool
     {
         return true;
     }

--- a/Adapter/SymfonyCache.php
+++ b/Adapter/SymfonyCache.php
@@ -12,6 +12,7 @@
 namespace Sonata\CacheBundle\Adapter;
 
 use Sonata\Cache\CacheAdapterInterface;
+use Sonata\Cache\CacheElementInterface;
 use Sonata\Cache\Exception\UnsupportedException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
@@ -87,7 +88,7 @@ class SymfonyCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function flushAll()
+    public function flushAll(): bool
     {
         return $this->flush(['all']);
     }
@@ -97,7 +98,7 @@ class SymfonyCache implements CacheAdapterInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function flush(array $keys = ['all'])
+    public function flush(array $keys = ['all']): bool
     {
         $result = true;
 
@@ -191,7 +192,7 @@ class SymfonyCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function has(array $keys)
+    public function has(array $keys): bool
     {
         throw new UnsupportedException('Symfony cache has() method does not exist');
     }
@@ -199,7 +200,7 @@ class SymfonyCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function set(array $keys, $data, $ttl = 84600, array $contextualKeys = [])
+    public function set(array $keys, $data, int $ttl = 84600, array $contextualKeys = []): CacheElementInterface
     {
         throw new UnsupportedException('Symfony cache set() method does not exist');
     }
@@ -207,7 +208,7 @@ class SymfonyCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function get(array $keys)
+    public function get(array $keys): CacheElementInterface
     {
         throw new UnsupportedException('Symfony cache get() method does not exist');
     }
@@ -215,7 +216,7 @@ class SymfonyCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function isContextual()
+    public function isContextual(): bool
     {
         return false;
     }

--- a/Adapter/SymfonyCache.php
+++ b/Adapter/SymfonyCache.php
@@ -193,7 +193,7 @@ class SymfonyCache implements CacheAdapterInterface
      */
     public function has(array $keys)
     {
-        throw new UnsupportedException('Symfony cache has() method does not exists');
+        throw new UnsupportedException('Symfony cache has() method does not exist');
     }
 
     /**
@@ -201,7 +201,7 @@ class SymfonyCache implements CacheAdapterInterface
      */
     public function set(array $keys, $data, $ttl = 84600, array $contextualKeys = [])
     {
-        throw new UnsupportedException('Symfony cache set() method does not exists');
+        throw new UnsupportedException('Symfony cache set() method does not exist');
     }
 
     /**
@@ -209,7 +209,7 @@ class SymfonyCache implements CacheAdapterInterface
      */
     public function get(array $keys)
     {
-        throw new UnsupportedException('Symfony cache get() method does not exists');
+        throw new UnsupportedException('Symfony cache get() method does not exist');
     }
 
     /**

--- a/Adapter/VarnishCache.php
+++ b/Adapter/VarnishCache.php
@@ -13,6 +13,7 @@ namespace Sonata\CacheBundle\Adapter;
 
 use Sonata\Cache\CacheAdapterInterface;
 use Sonata\Cache\CacheElement;
+use Sonata\Cache\CacheElementInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
@@ -78,7 +79,7 @@ class VarnishCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function flushAll()
+    public function flushAll(): bool
     {
         return $this->runCommand(
             $this->purgeInstruction == 'ban' ? 'ban.url' : 'purge',
@@ -89,7 +90,7 @@ class VarnishCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function flush(array $keys = [])
+    public function flush(array $keys = []): bool
     {
         $parameters = [];
         foreach ($keys as $key => $value) {
@@ -104,7 +105,7 @@ class VarnishCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function has(array $keys)
+    public function has(array $keys): bool
     {
         return true;
     }
@@ -112,7 +113,7 @@ class VarnishCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function get(array $keys)
+    public function get(array $keys): CacheElementInterface
     {
         if (!isset($keys['controller'])) {
             throw new \RuntimeException('Please define a controller key');
@@ -130,7 +131,7 @@ class VarnishCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function set(array $keys, $data, $ttl = CacheElement::DAY, array $contextualKeys = [])
+    public function set(array $keys, $data, int $ttl = CacheElement::DAY, array $contextualKeys = []): CacheElementInterface
     {
         return new CacheElement($keys, $data, $ttl, $contextualKeys);
     }
@@ -166,7 +167,7 @@ class VarnishCache implements CacheAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function isContextual()
+    public function isContextual(): bool
     {
         return true;
     }

--- a/Tests/Adapter/SymfonyCacheTest.php
+++ b/Tests/Adapter/SymfonyCacheTest.php
@@ -67,13 +67,13 @@ class SymfonyCacheTest extends TestCase
         $this->assertTrue($this->cache->flush([]));
         $this->assertTrue($this->cache->flushAll());
 
-        $this->setExpectedException('Sonata\Cache\Exception\UnsupportedException', 'Symfony cache set() method does not exists');
+        $this->setExpectedException('Sonata\Cache\Exception\UnsupportedException', 'Symfony cache set() method does not exist');
         $this->cache->set(['id' => 5], 'data');
 
-        $this->setExpectedException('Sonata\Cache\Exception\UnsupportedException', 'Symfony cache get() method does not exists');
+        $this->setExpectedException('Sonata\Cache\Exception\UnsupportedException', 'Symfony cache get() method does not exist');
         $this->cache->get(['id' => 5]);
 
-        $this->setExpectedException('Sonata\Cache\Exception\UnsupportedException', 'Symfony cache has() method does not exists');
+        $this->setExpectedException('Sonata\Cache\Exception\UnsupportedException', 'Symfony cache has() method does not exist');
         $this->cache->has(['id' => 5]);
     }
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -7,3 +7,8 @@ All the deprecated code introduced on 2.x is removed on 3.0.
 Please read [the 2.x upgrade guide](./UPGRADE-2.x.md) for more information.
 
 See also the [diff](https://github.com/sonata-project/SonataCacheBundle/compare/2.x...3.0.0)
+
+## Type hinting
+
+Now that only PHP 7 is supported, many signatures have changed: type hinting
+was added for the parameters or the return value.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/routing": "^2.8 || ^3.2",
         "symfony/security": "^2.8 || ^3.2",
         "symfony/process": "^2.8 || ^3.2",
-        "sonata-project/cache": "^1.0.3"
+        "sonata-project/cache": "^2.0.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",


### PR DESCRIPTION
I am targeting this branch, because this might be considered BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- support for sonata/cache 2

### Removed
- support for sonata/cache 1
```

## Subject 

Support for sonata/cache 1 is dropped because keeping it would imply
duplicating all the code in the cache adapters just to achieve
compatibility with the CacheAdapterInterface in both of its versions.