### PR TITLE
Drop PHPUnit 4 support

### DIFF
--- a/Tests/Adapter/ApcCacheTest.php
+++ b/Tests/Adapter/ApcCacheTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\CacheBundle\Tests\Adapter;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CacheBundle\Adapter\ApcCache;
 
-class ApcCacheTest extends \PHPUnit_Framework_TestCase
+class ApcCacheTest extends TestCase
 {
     /**
      * @var \Symfony\Component\Routing\RouterInterface
@@ -35,7 +36,7 @@ class ApcCacheTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('APC is not enabled in cli, please add apcu.enable_cli=On into the apcu.ini file');
         }
 
-        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $this->router = $this->createMock('Symfony\Component\Routing\RouterInterface');
 
         $this->cache = new ApcCache($this->router, 'token', 'prefix_', [], []);
     }

--- a/Tests/Adapter/SsiCacheTest.php
+++ b/Tests/Adapter/SsiCacheTest.php
@@ -11,18 +11,19 @@
 
 namespace Sonata\CacheBundle\Tests\Adapter\Cache;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CacheBundle\Adapter\SsiCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SsiCacheTest extends \PHPUnit_Framework_TestCase
+class SsiCacheTest extends TestCase
 {
     public function testInitCache()
     {
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('/cache/esi/TOKEN?controller=asdsad'));
 
-        $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
 
         $cache = new SsiCache('token', $router, $resolver);
 
@@ -47,10 +48,10 @@ class SsiCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testActionInvalidToken()
     {
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'));
 
-        $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
 
         $request = Request::create('cache/esi/TOKEN?controller=asdsad', 'get', [
             'token' => 'wrong',
@@ -62,9 +63,9 @@ class SsiCacheTest extends \PHPUnit_Framework_TestCase
 
     public function testValidToken()
     {
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
 
-        $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
         $resolver->expects($this->any())->method('getController')->will($this->returnValue(function () {
             return new Response();
         }));

--- a/Tests/Adapter/SymfonyCacheTest.php
+++ b/Tests/Adapter/SymfonyCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CacheBundle\Tests\Adapter;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CacheBundle\Adapter\SymfonyCache;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\RouterInterface;
@@ -20,7 +21,7 @@ use Symfony\Component\Routing\RouterInterface;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
+class SymfonyCacheTest extends TestCase
 {
     /**
      * @var SymfonyCache
@@ -42,8 +43,8 @@ class SymfonyCacheTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
-        $this->filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
+        $this->router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $this->filesystem = $this->createMock('Symfony\Component\Filesystem\Filesystem');
 
         $this->cache = new SymfonyCache(
             $this->router,

--- a/Tests/Adapter/VarnishCacheTest.php
+++ b/Tests/Adapter/VarnishCacheTest.php
@@ -11,18 +11,19 @@
 
 namespace Sonata\CacheBundle\Tests\Adapter\Cache;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CacheBundle\Adapter\VarnishCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class VarnishCacheTest extends \PHPUnit_Framework_TestCase
+class VarnishCacheTest extends TestCase
 {
     public function testInitCache()
     {
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('https://sonata-project.org/cache/esi/TOKEN?controller=asdsad'));
 
-        $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
 
         $cache = new VarnishCache('token', [], $router, 'ban', $resolver);
 
@@ -47,10 +48,10 @@ class VarnishCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testActionInvalidToken()
     {
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'));
 
-        $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
 
         $request = Request::create('cache/esi/TOKEN?controller=asdsad', 'get', [
             'token' => 'wrong',
@@ -62,9 +63,9 @@ class VarnishCacheTest extends \PHPUnit_Framework_TestCase
 
     public function testValidToken()
     {
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
 
-        $resolver = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
         $resolver->expects($this->any())->method('getController')->will($this->returnValue(function () {
             return new Response();
         }));
@@ -92,7 +93,7 @@ class VarnishCacheTest extends \PHPUnit_Framework_TestCase
                 sprintf("echo \"varnishadm -T 10.4.1.62:6082 -S /etc/varnish/secret {{ COMMAND }} '{{ EXPRESSION }}'\" >> %s", $tmpFile),
                 sprintf("echo \"varnishadm -T 10.4.1.66:6082 -S /etc/varnish/secret {{ COMMAND }} '{{ EXPRESSION }}'\" >> %s", $tmpFile),
             ],
-            $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->createMock('Symfony\Component\Routing\RouterInterface'),
             'ban'
         );
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\CacheBundle\Tests\DependencyInjection\Configuration;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CacheBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
 /**
  * Tests the Configuration class.
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * Asserts APC has default timeout values.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809