### PR TITLE
Add type hinting

### DIFF
--- a/Adapter/ApcCache.php
+++ b/Adapter/ApcCache.php
@@ -37,7 +37,7 @@ class ApcCache extends BaseApcCache
      * @param array           $servers An array of servers
      * @param array           $timeout An array of timeout options
      */
-    public function __construct(RouterInterface $router, $token, $prefix, array $servers, array $timeout = [])
+    public function __construct(RouterInterface $router, string $token, string $prefix, array $servers, array $timeout = [])
     {
         parent::__construct(null, $prefix, $servers, $timeout);
 
@@ -54,7 +54,7 @@ class ApcCache extends BaseApcCache
      *
      * @throws AccessDeniedHttpException
      */
-    public function cacheAction($token)
+    public function cacheAction(string $token): Response
     {
         if ($this->token == $token) {
             if (function_exists('opcache_reset')) {
@@ -77,7 +77,7 @@ class ApcCache extends BaseApcCache
     /**
      * {@inheritdoc}
      */
-    protected function getUrl()
+    protected function getUrl(): string
     {
         return $this->router->generate('sonata_cache_apc', ['token' => $this->token]);
     }

--- a/Adapter/ApcCache.php
+++ b/Adapter/ApcCache.php
@@ -77,7 +77,7 @@ class ApcCache extends BaseApcCache
     /**
      * {@inheritdoc}
      */
-    protected function getUrl(): string
+    protected function getUrl(): ?string
     {
         return $this->router->generate('sonata_cache_apc', ['token' => $this->token]);
     }

--- a/Adapter/SsiCache.php
+++ b/Adapter/SsiCache.php
@@ -39,7 +39,7 @@ class SsiCache implements CacheAdapterInterface
      * @param RouterInterface             $router
      * @param ControllerResolverInterface $resolver
      */
-    public function __construct($token, RouterInterface $router, ControllerResolverInterface $resolver = null)
+    public function __construct(string $token, RouterInterface $router, ControllerResolverInterface $resolver = null)
     {
         $this->token = $token;
         $this->router = $router;

--- a/Adapter/SsiCache.php
+++ b/Adapter/SsiCache.php
@@ -135,7 +135,7 @@ class SsiCache implements CacheAdapterInterface
      *
      * @return string
      */
-    protected function getUrl(array $keys)
+    protected function getUrl(array $keys): ?string
     {
         $parameters = [
             'token' => $this->computeHash($keys),
@@ -150,7 +150,7 @@ class SsiCache implements CacheAdapterInterface
      *
      * @return string
      */
-    protected function computeHash(array $keys)
+    protected function computeHash(array $keys): string
     {
         ksort($keys);
 

--- a/Adapter/SymfonyCache.php
+++ b/Adapter/SymfonyCache.php
@@ -73,7 +73,7 @@ class SymfonyCache implements CacheAdapterInterface
      * @param array           $servers             An array of servers
      * @param array           $timeouts            An array of timeout options
      */
-    public function __construct(RouterInterface $router, Filesystem $filesystem, $cacheDir, $token, $phpCodeCacheEnabled, array $types, array $servers, array $timeouts)
+    public function __construct(RouterInterface $router, Filesystem $filesystem, string $cacheDir, string $token, bool $phpCodeCacheEnabled, array $types, array $servers, array $timeouts)
     {
         $this->router = $router;
         $this->filesystem = $filesystem;
@@ -239,7 +239,7 @@ class SymfonyCache implements CacheAdapterInterface
     /**
      * Clears code cache with PHP OPcache.
      */
-    protected function clearPHPCodeCache()
+    protected function clearPHPCodeCache(): void
     {
         if (!$this->phpCodeCacheEnabled) {
             return;

--- a/Adapter/SymfonyCache.php
+++ b/Adapter/SymfonyCache.php
@@ -160,7 +160,7 @@ class SymfonyCache implements CacheAdapterInterface
      * @throws AccessDeniedHttpException if token is invalid
      * @throws \RuntimeException         if specified type is not in allowed types list
      */
-    public function cacheAction($token, $type)
+    public function cacheAction(string $token, string $type): Response
     {
         if ($this->token != $token) {
             throw new AccessDeniedHttpException('Invalid token');
@@ -228,7 +228,7 @@ class SymfonyCache implements CacheAdapterInterface
      *
      * @return string
      */
-    protected function getUrl($type)
+    protected function getUrl(string $type): ?string
     {
         return $this->router->generate('sonata_cache_symfony', [
             'token' => $this->token,

--- a/Adapter/VarnishCache.php
+++ b/Adapter/VarnishCache.php
@@ -67,7 +67,7 @@ class VarnishCache implements CacheAdapterInterface
      * @param string                           $purgeInstruction The purge instruction (purge in Varnish 2, ban in Varnish 3)
      * @param null|ControllerResolverInterface $resolver         A controller resolver instance
      */
-    public function __construct($token, array $servers, RouterInterface $router, string $purgeInstruction, ControllerResolverInterface $resolver = null)
+    public function __construct($token, array $servers, RouterInterface $router, string $purgeInstruction, ?ControllerResolverInterface $resolver = null)
     {
         $this->token = $token;
         $this->servers = $servers;
@@ -178,7 +178,7 @@ class VarnishCache implements CacheAdapterInterface
      *
      * @return bool
      */
-    protected function runCommand($command, $expression)
+    protected function runCommand(string $command, string $expression): bool
     {
         $return = true;
 
@@ -206,7 +206,7 @@ class VarnishCache implements CacheAdapterInterface
      *
      * @return string
      */
-    protected function getUrl(array $keys)
+    protected function getUrl(array $keys): ?string
     {
         $parameters = [
             'token' => $this->computeHash($keys),
@@ -223,7 +223,7 @@ class VarnishCache implements CacheAdapterInterface
      *
      * @return string
      */
-    protected function computeHash(array $keys)
+    protected function computeHash(array $keys): string
     {
         ksort($keys);
 
@@ -237,7 +237,7 @@ class VarnishCache implements CacheAdapterInterface
      *
      * @return string
      */
-    protected function normalize($key)
+    protected function normalize(string $key): string
     {
         return sprintf('x-sonata-cache-%s', str_replace(['_', '\\'], '-', strtolower($key)));
     }

--- a/Adapter/VarnishCache.php
+++ b/Adapter/VarnishCache.php
@@ -67,7 +67,7 @@ class VarnishCache implements CacheAdapterInterface
      * @param string                           $purgeInstruction The purge instruction (purge in Varnish 2, ban in Varnish 3)
      * @param null|ControllerResolverInterface $resolver         A controller resolver instance
      */
-    public function __construct($token, array $servers, RouterInterface $router, $purgeInstruction, ControllerResolverInterface $resolver = null)
+    public function __construct($token, array $servers, RouterInterface $router, string $purgeInstruction, ControllerResolverInterface $resolver = null)
     {
         $this->token = $token;
         $this->servers = $servers;

--- a/Command/BaseCacheCommand.php
+++ b/Command/BaseCacheCommand.php
@@ -20,7 +20,7 @@ abstract class BaseCacheCommand extends ContainerAwareCommand
      *
      * @return \Sonata\CacheBundle\Cache\CacheManagerInterface
      */
-    public function getManager()
+    public function getManager(): CacheManagerInterface
     {
         return $this->getContainer()->get('sonata.cache.manager');
     }

--- a/Command/CacheFlushAllCommand.php
+++ b/Command/CacheFlushAllCommand.php
@@ -20,7 +20,7 @@ class CacheFlushAllCommand extends BaseCacheCommand
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setName('sonata:cache:flush-all');
         $this->setDescription('Flush all information set in cache managers');
@@ -31,7 +31,7 @@ class CacheFlushAllCommand extends BaseCacheCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): void
     {
         $output->writeln('<info>clearing cache information</info>');
 

--- a/Command/CacheFlushCommand.php
+++ b/Command/CacheFlushCommand.php
@@ -20,7 +20,7 @@ class CacheFlushCommand extends BaseCacheCommand
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setName('sonata:cache:flush');
         $this->setDescription('Flush information');
@@ -32,7 +32,7 @@ class CacheFlushCommand extends BaseCacheCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): void
     {
         $keys = @json_decode($input->getOption('keys'), true);
 

--- a/DependencyInjection/Compiler/CacheCompilerPass.php
+++ b/DependencyInjection/Compiler/CacheCompilerPass.php
@@ -23,7 +23,7 @@ class CacheCompilerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $caches = [];
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder();
         $node = $treeBuilder->root('sonata_cache')->children();

--- a/DependencyInjection/SonataCacheExtension.php
+++ b/DependencyInjection/SonataCacheExtension.php
@@ -32,7 +32,7 @@ class SonataCacheExtension extends Extension
      * @param array            $configs   An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $processor = new Processor();
         $configuration = new Configuration();
@@ -72,7 +72,7 @@ class SonataCacheExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    public function configureInvalidation(ContainerBuilder $container, $config)
+    public function configureInvalidation(ContainerBuilder $container, array $config): void
     {
         $cacheManager = $container->getDefinition('sonata.cache.manager');
 
@@ -90,7 +90,7 @@ class SonataCacheExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    public function configureORM(ContainerBuilder $container, $config)
+    public function configureORM(ContainerBuilder $container, array $config): void
     {
         $cacheManager = $container->getDefinition('sonata.cache.orm.event_subscriber');
 
@@ -104,7 +104,7 @@ class SonataCacheExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    public function configurePHPCRODM(ContainerBuilder $container, $config)
+    public function configurePHPCRODM(ContainerBuilder $container, array $config): void
     {
         $cacheManager = $container->getDefinition('sonata.cache.phpcr_odm.event_subscriber');
 
@@ -120,7 +120,7 @@ class SonataCacheExtension extends Extension
      *
      * @throws \RuntimeException if the Mongo or Memcached library is not installed
      */
-    public function configureCache(ContainerBuilder $container, $config)
+    public function configureCache(ContainerBuilder $container, array $config): void
     {
         if ($config['default_cache']) {
             $container->setAlias('sonata.cache', $config['default_cache']);
@@ -225,7 +225,7 @@ class SonataCacheExtension extends Extension
      *
      * @throws \RuntimeException if the Mongo or Memcached library is not installed
      */
-    public function configureCounter(ContainerBuilder $container, $config)
+    public function configureCounter(ContainerBuilder $container, array $config): void
     {
         if ($config['default_counter']) {
             $container->setAlias('sonata.counter', $config['default_counter']);
@@ -295,7 +295,7 @@ class SonataCacheExtension extends Extension
      *
      * @return array
      */
-    public function configureServers(array $servers)
+    public function configureServers(array $servers): array
     {
         return array_map(
             function ($item) {
@@ -309,7 +309,7 @@ class SonataCacheExtension extends Extension
         );
     }
 
-    protected function checkMemcached()
+    protected function checkMemcached(): void
     {
         if (!class_exists('\Memcached', true)) {
             throw new \RuntimeException(<<<'HELP'
@@ -322,7 +322,7 @@ HELP
         }
     }
 
-    protected function checkApc()
+    protected function checkApc(): void
     {
         if (!function_exists('apc_fetch')) {
             throw new \RuntimeException(<<<'HELP'
@@ -335,7 +335,7 @@ HELP
         }
     }
 
-    protected function checkMongo()
+    protected function checkMongo(): void
     {
         if (!class_exists('\Mongo', true)) {
             throw new \RuntimeException(<<<'HELP'
@@ -348,7 +348,7 @@ HELP
         }
     }
 
-    protected function checkPRedis()
+    protected function checkPRedis(): void
     {
         if (!class_exists('\Predis\Client', true)) {
             throw new \RuntimeException(<<<HELP

--- a/Invalidation/DoctrineORMListenerContainerAware.php
+++ b/Invalidation/DoctrineORMListenerContainerAware.php
@@ -26,7 +26,7 @@ class DoctrineORMListenerContainerAware implements EventSubscriber
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
      * @param $service
      */
-    public function __construct(ContainerInterface $container, $service)
+    public function __construct(ContainerInterface $container, string $service)
     {
         $this->container = $container;
         $this->service = $service;

--- a/Invalidation/DoctrineORMListenerContainerAware.php
+++ b/Invalidation/DoctrineORMListenerContainerAware.php
@@ -46,7 +46,7 @@ class DoctrineORMListenerContainerAware implements EventSubscriber
     /**
      * @param \Doctrine\ORM\Event\LifecycleEventArgs $args
      */
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(LifecycleEventArgs $args): void
     {
         $this->load();
 
@@ -56,14 +56,14 @@ class DoctrineORMListenerContainerAware implements EventSubscriber
     /**
      * @param \Doctrine\ORM\Event\LifecycleEventArgs $args
      */
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(LifecycleEventArgs $args): void
     {
         $this->load();
 
         $this->listener->preUpdate($args);
     }
 
-    private function load()
+    private function load(): void
     {
         if ($this->listener) {
             return;

--- a/Invalidation/DoctrinePHPCRODMListenerContainerAware.php
+++ b/Invalidation/DoctrinePHPCRODMListenerContainerAware.php
@@ -46,7 +46,7 @@ class DoctrinePHPCRODMListenerContainerAware implements EventSubscriber
     /**
      * @param $args
      */
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(LifecycleEventArgs $args): void
     {
         $this->load();
 
@@ -56,14 +56,14 @@ class DoctrinePHPCRODMListenerContainerAware implements EventSubscriber
     /**
      * @param LifecycleEventArgs $args
      */
-    public function preUpdate(LifecycleEventArgs $args)
+    public function preUpdate(LifecycleEventArgs $args): void
     {
         $this->load();
 
         $this->listener->preUpdate($args);
     }
 
-    private function load()
+    private function load(): void
     {
         if ($this->listener) {
             return;

--- a/Invalidation/DoctrinePHPCRODMListenerContainerAware.php
+++ b/Invalidation/DoctrinePHPCRODMListenerContainerAware.php
@@ -26,7 +26,7 @@ class DoctrinePHPCRODMListenerContainerAware implements EventSubscriber
      * @param ContainerInterface $container
      * @param $service
      */
-    public function __construct(ContainerInterface $container, $service)
+    public function __construct(ContainerInterface $container, string $service)
     {
         $this->container = $container;
         $this->service = $service;
@@ -35,7 +35,7 @@ class DoctrinePHPCRODMListenerContainerAware implements EventSubscriber
     /**
      * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             Event::preRemove,

--- a/SonataCacheBundle.php
+++ b/SonataCacheBundle.php
@@ -17,14 +17,14 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SonataCacheBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
         $container->addCompilerPass(new CacheCompilerPass());
     }
 
-    public function boot()
+    public function boot(): void
     {
         $baseTemplateClass = $this->container->get('twig')->getBaseTemplateClass();
 

--- a/Tests/Adapter/ApcCacheTest.php
+++ b/Tests/Adapter/ApcCacheTest.php
@@ -26,7 +26,7 @@ class ApcCacheTest extends TestCase
      */
     private $cache;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!function_exists('apcu_store')) {
             $this->markTestSkipped('APC is not installed');
@@ -41,7 +41,7 @@ class ApcCacheTest extends TestCase
         $this->cache = new ApcCache($this->router, 'token', 'prefix_', [], []);
     }
 
-    public function testInitCache()
+    public function testInitCache(): void
     {
         $this->assertTrue($this->cache->flush([]));
         $this->assertTrue($this->cache->flushAll());
@@ -59,7 +59,7 @@ class ApcCacheTest extends TestCase
         $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
     }
 
-    public function testGetUrl()
+    public function testGetUrl(): void
     {
         $this->router
             ->expects($this->once())

--- a/Tests/Adapter/SsiCacheTest.php
+++ b/Tests/Adapter/SsiCacheTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SsiCacheTest extends TestCase
 {
-    public function testInitCache()
+    public function testInitCache(): void
     {
         $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('/cache/esi/TOKEN?controller=asdsad'));
@@ -46,7 +46,7 @@ class SsiCacheTest extends TestCase
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
-    public function testActionInvalidToken()
+    public function testActionInvalidToken(): void
     {
         $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'));
@@ -61,7 +61,7 @@ class SsiCacheTest extends TestCase
         $cache->cacheAction($request);
     }
 
-    public function testValidToken()
+    public function testValidToken(): void
     {
         $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
 

--- a/Tests/Adapter/SymfonyCacheTest.php
+++ b/Tests/Adapter/SymfonyCacheTest.php
@@ -42,7 +42,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Sets up cache adapter.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $this->filesystem = $this->createMock('Symfony\Component\Filesystem\Filesystem');
@@ -62,7 +62,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Tests cache initialization.
      */
-    public function testInitCache()
+    public function testInitCache(): void
     {
         $this->assertTrue($this->cache->flush([]));
         $this->assertTrue($this->cache->flushAll());
@@ -80,7 +80,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Tests cacheAction() method.
      */
-    public function testCacheAction()
+    public function testCacheAction(): void
     {
         // Given
         $this->filesystem->expects($this->once())->method('exists')->will($this->returnValue(true));
@@ -102,7 +102,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Tests cacheAction() method with an invalid token.
      */
-    public function testCacheActionWithInvalidToken()
+    public function testCacheActionWithInvalidToken(): void
     {
         // Given
         // When - Then expect exception
@@ -114,7 +114,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Tests cacheAction() method with an invalid cache type.
      */
-    public function testCacheActionWithInvalidType()
+    public function testCacheActionWithInvalidType(): void
     {
         // Given
         // When - Then expect exception
@@ -126,7 +126,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Asserts the flush method throws an exception if the IP version of the server cannot be detected.
      */
-    public function testFlushThrowsExceptionWithWrongIP()
+    public function testFlushThrowsExceptionWithWrongIP(): void
     {
         $cache = new SymfonyCache(
             $this->router,
@@ -149,7 +149,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Tests the flush method with IPv4.
      */
-    public function testFlushWithIPv4()
+    public function testFlushWithIPv4(): void
     {
         $cache = new SymfonyCache(
             $this->router,
@@ -172,7 +172,7 @@ class SymfonyCacheTest extends TestCase
         $builder = new MockBuilder();
         $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
             ->setName('socket_create')
-            ->setFunction(function () {
+            ->setFunction(function (): void {
                 $this->assertSame([AF_INET, SOCK_STREAM, SOL_TCP], func_get_args());
             })
             ->build();
@@ -184,7 +184,7 @@ class SymfonyCacheTest extends TestCase
             $builder = new MockBuilder();
             $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
                 ->setName($function)
-                ->setFunction(function () {
+                ->setFunction(function (): void {
                 })
                 ->build();
             $mock->enable();
@@ -202,7 +202,7 @@ class SymfonyCacheTest extends TestCase
     /**
      * Tests the flush method with IPv6.
      */
-    public function testFlushWithIPv6()
+    public function testFlushWithIPv6(): void
     {
         $cache = new SymfonyCache(
             $this->router,
@@ -225,7 +225,7 @@ class SymfonyCacheTest extends TestCase
         $builder = new MockBuilder();
         $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
             ->setName('socket_create')
-            ->setFunction(function () {
+            ->setFunction(function (): void {
                 $this->assertSame([AF_INET6, SOCK_STREAM, SOL_TCP], func_get_args());
             })
             ->build();
@@ -237,7 +237,7 @@ class SymfonyCacheTest extends TestCase
             $builder = new MockBuilder();
             $mock = $builder->setNamespace('Sonata\CacheBundle\Adapter')
                 ->setName($function)
-                ->setFunction(function () {
+                ->setFunction(function (): void {
                 })
                 ->build();
             $mock->enable();

--- a/Tests/Adapter/VarnishCacheTest.php
+++ b/Tests/Adapter/VarnishCacheTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class VarnishCacheTest extends TestCase
 {
-    public function testInitCache()
+    public function testInitCache(): void
     {
         $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('https://sonata-project.org/cache/esi/TOKEN?controller=asdsad'));
@@ -46,7 +46,7 @@ class VarnishCacheTest extends TestCase
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
-    public function testActionInvalidToken()
+    public function testActionInvalidToken(): void
     {
         $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->any())->method('generate')->will($this->returnValue('http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'));
@@ -61,7 +61,7 @@ class VarnishCacheTest extends TestCase
         $cache->cacheAction($request);
     }
 
-    public function testValidToken()
+    public function testValidToken(): void
     {
         $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
 
@@ -83,7 +83,7 @@ class VarnishCacheTest extends TestCase
         $cache->cacheAction($request);
     }
 
-    public function testRunCommand()
+    public function testRunCommand(): void
     {
         $tmpFile = tempnam(sys_get_temp_dir(), 'sonata-cache');
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -23,7 +23,7 @@ class ConfigurationTest extends TestCase
     /**
      * Asserts APC has default timeout values.
      */
-    public function testApcDefaultTimeout()
+    public function testApcDefaultTimeout(): void
     {
         $configs = [[
             'caches' => [
@@ -49,7 +49,7 @@ class ConfigurationTest extends TestCase
     /**
      * Asserts APC timeout has custom values.
      */
-    public function testApcCustomTimeout()
+    public function testApcCustomTimeout(): void
     {
         $expected = [
             'RCV' => ['sec' => 10, 'usec' => 0],
@@ -75,7 +75,7 @@ class ConfigurationTest extends TestCase
     /**
      * Asserts Symfony has default timeout values.
      */
-    public function testSymfonyDefaultTimeout()
+    public function testSymfonyDefaultTimeout(): void
     {
         $configs = [[
             'caches' => [
@@ -101,7 +101,7 @@ class ConfigurationTest extends TestCase
     /**
      * Asserts Symfony timeout has custom values.
      */
-    public function testSymfonyCustomTimeout()
+    public function testSymfonyCustomTimeout(): void
     {
         $expected = [
             'RCV' => ['sec' => 10, 'usec' => 0],

--- a/Twig/TwigTemplate13.php
+++ b/Twig/TwigTemplate13.php
@@ -25,7 +25,7 @@ abstract class TwigTemplate13 extends \Twig_Template
      *
      * @param \Sonata\Cache\Invalidation\Recorder $recorder
      */
-    public static function attachRecorder(Recorder $recorder)
+    public static function attachRecorder(Recorder $recorder): void
     {
         self::$recorder = $recorder;
     }

--- a/Twig/TwigTemplate14.php
+++ b/Twig/TwigTemplate14.php
@@ -25,7 +25,7 @@ abstract class TwigTemplate14 extends \Twig_Template
      *
      * @param \Sonata\Cache\Invalidation\Recorder $recorder
      */
-    public static function attachRecorder(Recorder $recorder)
+    public static function attachRecorder(Recorder $recorder): void
     {
         self::$recorder = $recorder;
     }


### PR DESCRIPTION
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- type hinting on most function signatures
```

## Subject
I avoided touching 2 classes that are most likely be tested because they extend `\TwigTemplate`, and twig isn't even required at the moment, see #158 