### PR TITLE
Show deprecation when using unsupported twig getAttribute function

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -18,6 +18,8 @@ UPGRADE 2.x
 | `Sonata\CacheBundle\Adapter\MongoCache` | `Sonata\Cache\Adapter\Cache\MongoCache` |
 | `Sonata\CacheBundle\Adapter\NoopCache` | `Sonata\Cache\Adapter\Cache\NoopCache` |
 | `Sonata\CacheBundle\Adapter\PRedisCache` | `Sonata\Cache\Adapter\Cache\PRedisCache` |
+| `Sonata\CacheBundle\Twig\TwigTemplate13` | none |
+| `Sonata\CacheBundle\Twig\TwigTemplate14` | none |
 
 ### Tests
 

--- a/src/Twig/TwigTemplate13.php
+++ b/src/Twig/TwigTemplate13.php
@@ -13,6 +13,9 @@ namespace Sonata\CacheBundle\Twig;
 
 use Sonata\Cache\Invalidation\Recorder;
 
+/**
+ * @deprecated TwigTemplate13 is deprecated since 2.x and will be removed in 3.0.
+ */
 abstract class TwigTemplate13 extends \Twig_Template
 {
     /**

--- a/src/Twig/TwigTemplate14.php
+++ b/src/Twig/TwigTemplate14.php
@@ -13,6 +13,9 @@ namespace Sonata\CacheBundle\Twig;
 
 use Sonata\Cache\Invalidation\Recorder;
 
+/**
+ * @deprecated TwigTemplate14 is deprecated since 2.x and will be removed in 3.0.
+ */
 abstract class TwigTemplate14 extends \Twig_Template
 {
     /**


### PR DESCRIPTION
I am targeting this branch, because it's targeting twig v2, which has no support for getAttribute anymore.

Related to #158

## Changelog

```markdown
### Deprecated
- Deprecation warning when using `\Twig_Template::getAttribute` function.

```

## Subject

As discussed in #158, twig dropped support for \Twig_Template::getAttribute, so we can't override it anymore. There is no solution for this problem yet, so I've added a deprecation warning and a request to create an issue when encountering issues related to cache invalidation.

I'm not very good at creating good explainatory messages, so please any feedback is welcomed.