### PR TITLE
remove use of other bundles parameters in dependency injection extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "symfony/config": "^2.8 || ^3.2",
+        "symfony/dependency-injection": "^2.8 || ^3.2",
         "symfony/filesystem": "^2.8 || ^3.2",
         "symfony/http-foundation": "^2.8 || ^3.2",
         "symfony/routing": "^2.8 || ^3.2",
@@ -28,6 +29,9 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
+        "doctrine/phpcr-odm": "^1.0",
+        "jackalope/jackalope": "^1.0",
+        "jackalope/jackalope-doctrine-dbal": "^1.0",
         "php-mock/php-mock": "^1.0",
         "predis/predis": "^0.8 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",

--- a/src/DependencyInjection/SonataCacheExtension.php
+++ b/src/DependencyInjection/SonataCacheExtension.php
@@ -51,7 +51,7 @@ class SonataCacheExtension extends Extension
         }
 
         $usePhpcrOdm = 'auto' == $config['cache_invalidation']['phpcr_odm_listener'] ?
-            class_exists('Doctrine\\PHPCR\\ODM\\Version') :
+            class_exists('Doctrine\\ODM\\PHPCR\\Version') :
             $config['cache_invalidation']['phpcr_odm_listener'];
         if ($usePhpcrOdm) {
             $loader->load('phpcr_odm.xml');
@@ -92,12 +92,9 @@ class SonataCacheExtension extends Extension
      */
     public function configureORM(ContainerBuilder $container, $config)
     {
-        $cacheManager = $container->getDefinition('sonata.cache.orm.event_subscriber');
-
-        $connections = array_keys($container->getParameter('doctrine.connections'));
-        foreach ($connections as $conn) {
-            $cacheManager->addTag('doctrine.event_subscriber', ['connection' => $conn]);
-        }
+        $container->getDefinition('sonata.cache.orm.event_subscriber')
+            ->addTag('doctrine.event_subscriber')
+        ;
     }
 
     /**
@@ -106,12 +103,9 @@ class SonataCacheExtension extends Extension
      */
     public function configurePHPCRODM(ContainerBuilder $container, $config)
     {
-        $cacheManager = $container->getDefinition('sonata.cache.phpcr_odm.event_subscriber');
-
-        $sessions = array_keys($container->getParameter('doctrine_phpcr.odm.sessions'));
-        foreach ($sessions as $session) {
-            $cacheManager->addTag('doctrine_phpcr.event_subscriber', ['session' => $session]);
-        }
+        $container->getDefinition('sonata.cache.phpcr_odm.event_subscriber')
+            ->addTag('doctrine_phpcr.event_subscriber')
+        ;
     }
 
     /**

--- a/tests/DependencyInjection/SonataCacheExtensionTest.php
+++ b/tests/DependencyInjection/SonataCacheExtensionTest.php
@@ -15,6 +15,11 @@ use PHPUnit\Framework\TestCase;
 use Sonata\CacheBundle\DependencyInjection\SonataCacheExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * Functional test for SonataCacheExtension.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ */
 class SonataCacheExtensionTest extends TestCase
 {
     public function testUseCacheInvalidationDoctrineListeners()

--- a/tests/DependencyInjection/SonataCacheExtensionTest.php
+++ b/tests/DependencyInjection/SonataCacheExtensionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CacheBundle\Tests\DependencyInjection\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CacheBundle\DependencyInjection\SonataCacheExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SonataCacheExtensionTest extends TestCase
+{
+    public function testUseCacheInvalidationDoctrineListeners()
+    {
+        $container = new ContainerBuilder();
+        $extension = new SonataCacheExtension();
+        $extension->load([], $container);
+
+        $this->assertTrue($container->hasDefinition('sonata.cache.orm.event_subscriber'));
+        $this->assertTrue($container->hasDefinition('sonata.cache.phpcr_odm.event_subscriber'));
+    }
+}


### PR DESCRIPTION
I'm targeting `2.x` branch because it does not introduce any backward incompatible change.

Closes #166 

## Changelog
```markdown
### Fixed
- DoctrineBundle and DoctrinePHPCRBundle can be loaded before or after SonataCacheBundle.
```

## To do
- [x] Add tests

## Subject

This will improve DX when bundle is used with Symfony Flex. I wanted to add tests but this bundle does not depend on `symfony/framework-bundle`. Can I add it to dependencies and write some tests?
