### PR TITLE
fix autoload routes for testing

### DIFF
--- a/src/Adapter/ApcCache.php
+++ b/src/Adapter/ApcCache.php
@@ -67,7 +67,7 @@ class ApcCache extends BaseApcCache
 
             return new Response('ok', 200, [
                 'Cache-Control' => 'no-cache, must-revalidate',
-                'Content-Length' => 2, // to prevent chunked transfer encoding.
+                'Content-Length' => 2, // to prevent chunked transfer encoding
             ]);
         }
 

--- a/tests/autoload.php.dist
+++ b/tests/autoload.php.dist
@@ -3,9 +3,9 @@
 // if the bundle is within a symfony project, try to reuse the project's autoload
 
 $files = array(
-    __DIR__.'/../../vendor/autoload.php',
-    __DIR__.'/../../../../../app/autoload.php',
-    __DIR__.'/../../../../../apps/autoload.php',
+    __DIR__.'/../vendor/autoload.php',
+    __DIR__.'/../../../../app/autoload.php',
+    __DIR__.'/../../../../apps/autoload.php',
 );
 
 $autoload = false;


### PR DESCRIPTION
This is a missing change from refactor structure, pretty critical because it makes test unable to execute but still gives a green build