### PR TITLE
Forward compatibility

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -21,6 +21,10 @@ UPGRADE 2.x
 | `Sonata\CacheBundle\Twig\TwigTemplate13` | none |
 | `Sonata\CacheBundle\Twig\TwigTemplate14` | none |
 
+Both `Sonata\CacheBundle\Adapter\SsiCache` and
+`Sonata\CacheBundle\Adapter\VarnishCache` now require you provide their
+constructor with an `ArgumentResolverInterface` instance.
+
 ### Tests
 
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php-mock/php-mock": "^1.0",
         "predis/predis": "^0.8 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^3.3"
+        "symfony/phpunit-bridge": "^3.3.12"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "ORM support",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,10 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <filter>
         <whitelist>
             <directory suffix=".php">./src/</directory>

--- a/tests/Adapter/SsiCacheTest.php
+++ b/tests/Adapter/SsiCacheTest.php
@@ -12,35 +12,68 @@
 namespace Sonata\CacheBundle\Tests\Adapter\Cache;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Cache\CacheElement;
 use Sonata\CacheBundle\Adapter\SsiCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\Routing\RouterInterface;
 
+/**
+ * NEXT_MAJOR: remove interface_exists conditions when dropping sf < 3.1.
+ */
 class SsiCacheTest extends TestCase
 {
+    private $router;
+    private $controllerResolver;
+    private $argumentResolver;
+    private $cache;
+
+    protected function setUp()
+    {
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->controllerResolver = $this->createMock(ControllerResolverInterface::class);
+        if (interface_exists(ArgumentResolverInterface::class)) {
+            $this->argumentResolver = $this->createMock(ArgumentResolverInterface::class);
+        }
+        $this->cache = new SsiCache(
+            'token',
+            $this->router,
+            $this->controllerResolver,
+            interface_exists(ArgumentResolverInterface::class) ?
+            $this->argumentResolver :
+            null
+        );
+    }
+
     public function testInitCache()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $router->expects($this->any())->method('generate')->will($this->returnValue('/cache/esi/TOKEN?controller=asdsad'));
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue('/cache/esi/TOKEN?controller=asdsad'));
 
-        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $this->assertTrue($this->cache->flush([]));
+        $this->assertTrue($this->cache->flushAll());
 
-        $cache = new SsiCache('token', $router, $resolver);
+        $cacheElement = $this->cache->set(['id' => 7], 'data');
 
-        $this->assertTrue($cache->flush([]));
-        $this->assertTrue($cache->flushAll());
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
-        $cacheElement = $cache->set(['id' => 7], 'data');
+        $this->assertTrue($this->cache->has(['id' => 7]));
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $cacheElement = $this->cache->get([
+            'id' => 7,
+            'controller' => 'foo.service::runAction',
+            'parameters' => [],
+        ]);
 
-        $this->assertTrue($cache->has(['id' => 7]));
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
-        $cacheElement = $cache->get(['id' => 7, 'controller' => 'foo.service::runAction', 'parameters' => []]);
-
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
-
-        $this->assertEquals('<!--# include virtual="/cache/esi/TOKEN?controller=asdsad" -->', $cacheElement->getData()->getContent());
+        $this->assertEquals(
+            '<!--# include virtual="/cache/esi/TOKEN?controller=asdsad" -->',
+            $cacheElement->getData()->getContent()
+        );
     }
 
     /**
@@ -48,28 +81,34 @@ class SsiCacheTest extends TestCase
      */
     public function testActionInvalidToken()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $router->expects($this->any())->method('generate')->will($this->returnValue('http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'));
-
-        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue(
+                'http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'
+            ));
 
         $request = Request::create('cache/esi/TOKEN?controller=asdsad', 'get', [
             'token' => 'wrong',
         ]);
 
-        $cache = new SsiCache('token', $router, $resolver);
-        $cache->cacheAction($request);
+        $this->cache->cacheAction($request);
     }
 
     public function testValidToken()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $this->controllerResolver->expects($this->any())
+            ->method('getController')
+            ->will($this->returnValue(function () {
+                return new Response();
+            }));
 
-        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
-        $resolver->expects($this->any())->method('getController')->will($this->returnValue(function () {
-            return new Response();
-        }));
-        $resolver->expects($this->any())->method('getArguments')->will($this->returnValue([]));
+        $resolver = interface_exists(ArgumentResolverInterface::class) ?
+            $this->argumentResolver :
+            $this->controllerResolver;
+
+        $resolver->expects($this->any())
+            ->method('getArguments')
+            ->will($this->returnValue([]));
 
         $request = Request::create('cache/esi/TOKEN', 'get', [
             'token' => '44befdbd93f304ea693023aa6587729bed76a206ecdacfd9bbd9b43fcf2e1664',
@@ -79,7 +118,21 @@ class SsiCacheTest extends TestCase
             ],
         ]);
 
-        $cache = new SsiCache('token', $router, $resolver);
-        $cache->cacheAction($request);
+        $this->cache->cacheAction($request);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a "Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface" instance to "Sonata\CacheBundle\Adapter\SsiCache::__construct" is deprecated since 3.x and will not be possible in 4.0
+     */
+    public function testConstructorLegacy()
+    {
+        if (!interface_exists(ArgumentResolverInterface::class)) {
+            $this->markTestSkipped(
+                'Running Symfony < 3.1'
+            );
+        }
+
+        new SsiCache('token', $this->router, $this->controllerResolver);
     }
 }

--- a/tests/Adapter/SymfonyCacheTest.php
+++ b/tests/Adapter/SymfonyCacheTest.php
@@ -55,7 +55,10 @@ class SymfonyCacheTest extends TestCase
             false,
             ['all', 'translations'],
             [],
-            []
+            [
+                'RCV' => ['sec' => 2, 'usec' => 0],
+                'SND' => ['sec' => 2, 'usec' => 0],
+            ]
         );
     }
 
@@ -138,7 +141,10 @@ class SymfonyCacheTest extends TestCase
             [
                 ['ip' => 'wrong ip'],
             ],
-            []
+            [
+                'RCV' => ['sec' => 2, 'usec' => 0],
+                'SND' => ['sec' => 2, 'usec' => 0],
+            ]
         );
 
         $this->setExpectedException('\InvalidArgumentException', '"wrong ip" is not a valid ip address');

--- a/tests/Adapter/VarnishCacheTest.php
+++ b/tests/Adapter/VarnishCacheTest.php
@@ -12,35 +12,69 @@
 namespace Sonata\CacheBundle\Tests\Adapter\Cache;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Cache\CacheElement;
 use Sonata\CacheBundle\Adapter\VarnishCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class VarnishCacheTest extends TestCase
 {
+    private $router;
+    private $controllerResolver;
+    private $argumentResolver;
+    private $cache;
+
+    protected function setUp()
+    {
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->controllerResolver = $this->createMock(ControllerResolverInterface::class);
+        if (interface_exists(ArgumentResolverInterface::class)) {
+            $this->argumentResolver = $this->createMock(ArgumentResolverInterface::class);
+        }
+        $this->cache = new VarnishCache(
+            'token',
+            [],
+            $this->router,
+            'ban',
+            $this->controllerResolver,
+            interface_exists(ArgumentResolverInterface::class) ?
+            $this->argumentResolver :
+            null
+        );
+    }
+
     public function testInitCache()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $router->expects($this->any())->method('generate')->will($this->returnValue('https://sonata-project.org/cache/esi/TOKEN?controller=asdsad'));
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue(
+                'https://sonata-project.org/cache/esi/TOKEN?controller=asdsad'
+            ));
 
-        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $this->assertTrue($this->cache->flush([]));
+        $this->assertTrue($this->cache->flushAll());
 
-        $cache = new VarnishCache('token', [], $router, 'ban', $resolver);
+        $cacheElement = $this->cache->set(['id' => 7], 'data');
 
-        $this->assertTrue($cache->flush([]));
-        $this->assertTrue($cache->flushAll());
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
-        $cacheElement = $cache->set(['id' => 7], 'data');
+        $this->assertTrue($this->cache->has(['id' => 7]));
 
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
+        $cacheElement = $this->cache->get([
+            'id' => 7,
+            'controller' => 'foo.service::runAction',
+            'parameters' => [],
+        ]);
 
-        $this->assertTrue($cache->has(['id' => 7]));
+        $this->assertInstanceOf(CacheElement::class, $cacheElement);
 
-        $cacheElement = $cache->get(['id' => 7, 'controller' => 'foo.service::runAction', 'parameters' => []]);
-
-        $this->assertInstanceOf('Sonata\Cache\CacheElement', $cacheElement);
-
-        $this->assertEquals('<esi:include src="https://sonata-project.org/cache/esi/TOKEN?controller=asdsad"/>', $cacheElement->getData()->getContent());
+        $this->assertEquals(
+            '<esi:include src="https://sonata-project.org/cache/esi/TOKEN?controller=asdsad"/>',
+            $cacheElement->getData()->getContent()
+        );
     }
 
     /**
@@ -48,28 +82,33 @@ class VarnishCacheTest extends TestCase
      */
     public function testActionInvalidToken()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $router->expects($this->any())->method('generate')->will($this->returnValue('http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'));
-
-        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue(
+                'http://sonata-project.orf/cache/esi/TOKEN?controller=asdsad'
+            ));
 
         $request = Request::create('cache/esi/TOKEN?controller=asdsad', 'get', [
             'token' => 'wrong',
         ]);
 
-        $cache = new VarnishCache('token', [], $router, 'ban', $resolver);
-        $cache->cacheAction($request);
+        $this->cache->cacheAction($request);
     }
 
     public function testValidToken()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $this->controllerResolver->expects($this->any())
+            ->method('getController')
+            ->will($this->returnValue(function () {
+                return new Response();
+            }));
+        $resolver = interface_exists(ArgumentResolverInterface::class) ?
+            $this->argumentResolver :
+            $this->controllerResolver;
 
-        $resolver = $this->createMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface');
-        $resolver->expects($this->any())->method('getController')->will($this->returnValue(function () {
-            return new Response();
-        }));
-        $resolver->expects($this->any())->method('getArguments')->will($this->returnValue([]));
+        $resolver->expects($this->any())
+            ->method('getArguments')
+            ->will($this->returnValue([]));
 
         $request = Request::create('cache/esi/TOKEN', 'get', [
             'token' => '44befdbd93f304ea693023aa6587729bed76a206ecdacfd9bbd9b43fcf2e1664',
@@ -79,8 +118,7 @@ class VarnishCacheTest extends TestCase
             ],
         ]);
 
-        $cache = new VarnishCache('token', [], $router, 'ban', $resolver);
-        $cache->cacheAction($request);
+        $this->cache->cacheAction($request);
     }
 
     public function testRunCommand()
@@ -93,8 +131,10 @@ class VarnishCacheTest extends TestCase
                 sprintf("echo \"varnishadm -T 10.4.1.62:6082 -S /etc/varnish/secret {{ COMMAND }} '{{ EXPRESSION }}'\" >> %s", $tmpFile),
                 sprintf("echo \"varnishadm -T 10.4.1.66:6082 -S /etc/varnish/secret {{ COMMAND }} '{{ EXPRESSION }}'\" >> %s", $tmpFile),
             ],
-            $this->createMock('Symfony\Component\Routing\RouterInterface'),
-            'ban'
+            $this->router,
+            'ban',
+            $this->controllerResolver,
+            $this->argumentResolver
         );
 
         $method = new \ReflectionMethod($cache, 'runCommand');
@@ -110,5 +150,20 @@ CMD
         , file_get_contents($tmpFile));
 
         unlink($tmpFile);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a "Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface" instance to "Sonata\CacheBundle\Adapter\VarnishCache::__construct" is deprecated since 3.x and will not be possible in 4.0
+     */
+    public function testConstructorLegacy()
+    {
+        if (!interface_exists(ArgumentResolverInterface::class)) {
+            $this->markTestSkipped(
+                'Running Symfony < 3.1'
+            );
+        }
+
+        new VarnishCache('token', [], $this->router, 'ban');
     }
 }


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- omitting the `$argumentsResolver` argument when instanciating `SsiCache` or `VarnishCache`

### Fixed
- deprecation about using a `ControllerResolverInterface` to resolve arguments
```


## Subject

This should make the bundle compatible with sf 3.4 and sf 4.0 according to the test suite.
