### PR TITLE
make symfony/config allowed for symfony 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/config": "^2.8 || ^3.2",
+        "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/filesystem": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",


### PR DESCRIPTION
### Changelog

```markdown
### Fixed
-  Symfony 4.0 for `symfony/config`

```
I realized that Symfony 4.0 isn't available for config component.