### PR TITLE
all0w cache component in version 2.x to get thier new changes too.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/routing": "^2.8 || ^3.2 || ^4.0",
         "symfony/security": "^2.8 || ^3.2 || ^4.0",
         "symfony/process": "^2.8 || ^3.2 || ^4.0",
-        "sonata-project/cache": "^1.0.3"
+        "sonata-project/cache": "^1.0.3 || ^2.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",


### PR DESCRIPTION

I am targeting this branch, because this is the latest one

## Changelog

```markdown
### Changed
- allowed `sonta-project/cach` version 2.x
```
## Subject

There was a change on `sonata-project/cache` https://github.com/sonata-project/cache/pull/103 which we can't ever reach with cache-bundle, so the cache-bundle should also allow 2.x of its component.
