### PR TITLE
Clean composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "php-mock/php-mock": "^2.0",
         "predis/predis": "^1.0",
-        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/phpunit-bridge": "^3.3.12 || ^4.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "php-mock/php-mock": "^2.0",
         "predis/predis": "^1.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2",
         "symfony/framework-bundle": "^2.8 || ^3.2",
         "symfony/phpunit-bridge": "^3.3.12 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "php-mock/php-mock": "^2.0",
         "predis/predis": "^1.0",
-        "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/dependency-injection": "^2.8 || ^3.2",
         "symfony/framework-bundle": "^2.8 || ^3.2",
         "symfony/phpunit-bridge": "^3.3.12 || ^4.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it fixes things that are only on master, strangely.


## Changelog

None since this is master and stable does not have these issues
