### PR TITLE
Minor composer improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
         "doctrine/phpcr-odm": "PHPCR ODM support",
         "predis/predis": "Install redis php"
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/filesystem": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/process": "^2.8 || ^3.2 || ^4.0",
         "symfony/routing": "^2.8 || ^3.2 || ^4.0",
         "symfony/security": "^2.8 || ^3.2 || ^4.0"
@@ -36,6 +37,8 @@
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "php-mock/php-mock": "^1.0",
         "predis/predis": "^0.8 || ^1.0",
+        "symfony/console": "^2.8 || ^3.2 || ^4.0",
+        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/phpunit-bridge": "^3.3.12 || ^4.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "predis/predis": "^0.8 || ^1.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
-        "symfony/phpunit-bridge": "^3.3.12 || ^4.0"
+        "symfony/phpunit-bridge": "^4.0"
     },
     "suggest": {
         "ext-apcu": "Caching with ext/apcu",

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/process": "^2.8 || ^3.2 || ^4.0",
-        "symfony/routing": "^2.8 || ^3.2 || ^4.0",
-        "symfony/security": "^2.8 || ^3.2 || ^4.0"
+        "symfony/routing": "^2.8 || ^3.2 || ^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Subject

<!-- Describe your Pull Request content here -->
- Declare missing dependencies
- Add framework-bundle and console to require-dev (this comes from master mostly)
- Sort packages
- phpunit-bridge 4.0 only
- Removed unused security dependency (it was added here, replacing whole symfony/symfony package, but I do not see any usage here: https://github.com/sonata-project/SonataCacheBundle/commit/7c1f71036daa6d4fe29d0bb41267ff7731c68d67)

This bundle also needs:
- Declare console commands on services.xml (compat with SF4)