### PR TITLE
Fix sonata.cache.invalidation.simple service definition

### DIFF
--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -62,7 +62,7 @@
             <argument type="collection"/>
             <argument/>
         </service>
-        <service id="sonata.cache.invalidation.simple" class="Sonata\CacheBundle\Invalidation\SimpleCacheInvalidation">
+        <service id="sonata.cache.invalidation.simple" class="Sonata\Cache\Invalidation\SimpleCacheInvalidation">
             <argument type="service" id="logger"/>
         </service>
     </services>


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed sonata.cache.invalidation.simple service definition typo
```
## Subject

`Sonata\CacheBundle\Invalidation\SimpleCacheInvalidation` class is deprecated in 2.x branch and was moved to `sonata-project/cache` package to `Sonata\Cache\Invalidation\SimpleCacheInvalidation` in master