### PR TITLE
Commands as services

### DIFF
--- a/src/DependencyInjection/SonataCacheExtension.php
+++ b/src/DependencyInjection/SonataCacheExtension.php
@@ -41,6 +41,7 @@ class SonataCacheExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('cache.xml');
         $loader->load('counter.xml');
+        $loader->load('command.xml');
 
         $useOrm = 'auto' == $config['cache_invalidation']['orm_listener'] ?
             class_exists('Doctrine\\ORM\\Version') :

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\CacheBundle\Command\CacheFlushAllCommand" class="Sonata\CacheBundle\Command\CacheFlushAllCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\CacheBundle\Command\CacheFlushCommand" class="Sonata\CacheBundle\Command\CacheFlushCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC fix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Commands not working on symfony4
```

## Subject

On symfony4 commands are not working as they are not registered as a services, this fixes it.