### PR TITLE
Optional usage of twig service

### DIFF
--- a/src/SonataCacheBundle.php
+++ b/src/SonataCacheBundle.php
@@ -26,14 +26,16 @@ class SonataCacheBundle extends Bundle
 
     public function boot()
     {
-        $baseTemplateClass = $this->container->get('twig')->getBaseTemplateClass();
+        if ($this->container->has('twig')) {
+            $baseTemplateClass = $this->container->get('twig')->getBaseTemplateClass();
 
-        if (empty($baseTemplateClass)) {
-            return;
-        }
+            if (empty($baseTemplateClass)) {
+                return;
+            }
 
-        if (method_exists($baseTemplateClass, 'attachRecorder')) {
-            call_user_func([$baseTemplateClass, 'attachRecorder'], $this->container->get('sonata.cache.recorder'));
+            if (method_exists($baseTemplateClass, 'attachRecorder')) {
+                call_user_func([$baseTemplateClass, 'attachRecorder'], $this->container->get('sonata.cache.recorder'));
+            }
         }
     }
 }


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

See #206

## Changelog

```markdown
### Fixed
- Usage of twig service in SonataCacheBundle is optional now
```

## Subject

To find Twig base template class, Sonata\CacheBundle\SonataCacheBundle::boot method gets twig service from container and does not check if it exists.