### PR TITLE
Remove deprecated twig

### DIFF
--- a/src/SonataCacheBundle.php
+++ b/src/SonataCacheBundle.php
@@ -25,17 +25,4 @@ class SonataCacheBundle extends Bundle
 
         $container->addCompilerPass(new CacheCompilerPass());
     }
-
-    public function boot(): void
-    {
-        $baseTemplateClass = $this->container->get('twig')->getBaseTemplateClass();
-
-        if (empty($baseTemplateClass)) {
-            return;
-        }
-
-        if (method_exists($baseTemplateClass, 'attachRecorder')) {
-            call_user_func([$baseTemplateClass, 'attachRecorder'], $this->container->get('sonata.cache.recorder'));
-        }
-    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- removed calling deprecated twig classes in bundle boot
```
## Subject

This should have been part of https://github.com/sonata-project/SonataCacheBundle/pull/204 but I did not see it, so let's remove it.