### PR TITLE
Fix twig init on boot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/phpunit-bridge": "^4.0",
-        "twig/twig": "^2.4"
+        "twig/twig": "^2.4 | ^1.35"
     },
     "suggest": {
         "ext-apcu": "Caching with ext/apcu",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/phpunit-bridge": "^4.0",
-        "twig/twig": "^2.4 | ^1.35"
+        "twig/twig": "^2.4 || ^1.35"
     },
     "suggest": {
         "ext-apcu": "Caching with ext/apcu",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/phpunit-bridge": "^4.0",
-        "twig/twig": "^2.4 || ^1.35"
+        "twig/twig": "^1.35 || ^2.4"
     },
     "suggest": {
         "ext-apcu": "Caching with ext/apcu",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "predis/predis": "^0.8 || ^1.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
-        "symfony/phpunit-bridge": "^4.0"
+        "symfony/phpunit-bridge": "^4.0",
+        "twig/twig": "^2.4"
     },
     "suggest": {
         "ext-apcu": "Caching with ext/apcu",

--- a/src/Cache/TwigTemplateRecorderInjector.php
+++ b/src/Cache/TwigTemplateRecorderInjector.php
@@ -24,7 +24,7 @@ use Twig_Extension;
  */
 final class TwigTemplateRecorderInjector extends Twig_Extension
 {
-    public function __construct (Twig_Environment $twig, Recorder $recorder)
+    public function __construct(Twig_Environment $twig, Recorder $recorder)
     {
         $baseTemplateClass = $twig->getBaseTemplateClass();
 

--- a/src/Cache/TwigTemplateRecorderInjector.php
+++ b/src/Cache/TwigTemplateRecorderInjector.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CacheBundle\Cache;
+
+use Sonata\Cache\Invalidation\Recorder;
+use Twig_Environment;
+use Twig_Extension;
+
+/**
+ * @internal
+ *
+ * Ugly hack to run this code on twig initialization
+ *
+ * NEXT_MAJOR: remove
+ */
+final class TwigTemplateRecorderInjector extends Twig_Extension
+{
+    public function __construct (Twig_Environment $twig, Recorder $recorder)
+    {
+        $baseTemplateClass = $twig->getBaseTemplateClass();
+
+        if (empty($baseTemplateClass)) {
+            return;
+        }
+
+        if (method_exists($baseTemplateClass, 'attachRecorder')) {
+            call_user_func([$baseTemplateClass, 'attachRecorder'], $recorder);
+        }
+    }
+}

--- a/src/Cache/TwigTemplateRecorderInjector.php
+++ b/src/Cache/TwigTemplateRecorderInjector.php
@@ -14,26 +14,42 @@ namespace Sonata\CacheBundle\Cache;
 use Sonata\Cache\Invalidation\Recorder;
 use Twig_Environment;
 use Twig_Extension;
+use Twig_Extension_InitRuntimeInterface;
 
 /**
  * @internal
  *
- * Ugly hack to run this code on twig initialization
- *
  * NEXT_MAJOR: remove
  */
-final class TwigTemplateRecorderInjector extends Twig_Extension
+final class TwigTemplateRecorderInjector extends Twig_Extension implements Twig_Extension_InitRuntimeInterface
 {
-    public function __construct(Twig_Environment $twig, Recorder $recorder)
+    /**
+     * @var Recorder
+     */
+    private $recorder;
+
+    public function __construct(Recorder $recorder)
     {
-        $baseTemplateClass = $twig->getBaseTemplateClass();
+        $this->recorder = $recorder;
+    }
+
+    /**
+     * Initializes the runtime environment.
+     *
+     * This is where you can load some file that contains filter functions for instance.
+     *
+     * @param Twig_Environment $environment The current Twig_Environment instance
+     */
+    public function initRuntime(Twig_Environment $environment)
+    {
+        $baseTemplateClass = $environment->getBaseTemplateClass();
 
         if (empty($baseTemplateClass)) {
             return;
         }
 
         if (method_exists($baseTemplateClass, 'attachRecorder')) {
-            call_user_func([$baseTemplateClass, 'attachRecorder'], $recorder);
+            call_user_func([$baseTemplateClass, 'attachRecorder'], $this->recorder);
         }
     }
 }

--- a/src/Cache/TwigTemplateRecorderInjector.php
+++ b/src/Cache/TwigTemplateRecorderInjector.php
@@ -12,16 +12,16 @@
 namespace Sonata\CacheBundle\Cache;
 
 use Sonata\Cache\Invalidation\Recorder;
-use Twig_Environment;
-use Twig_Extension;
-use Twig_Extension_InitRuntimeInterface;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\InitRuntimeInterface;
 
 /**
  * @internal
  *
  * NEXT_MAJOR: remove
  */
-final class TwigTemplateRecorderInjector extends Twig_Extension implements Twig_Extension_InitRuntimeInterface
+final class TwigTemplateRecorderInjector extends AbstractExtension implements InitRuntimeInterface
 {
     /**
      * @var Recorder
@@ -33,14 +33,7 @@ final class TwigTemplateRecorderInjector extends Twig_Extension implements Twig_
         $this->recorder = $recorder;
     }
 
-    /**
-     * Initializes the runtime environment.
-     *
-     * This is where you can load some file that contains filter functions for instance.
-     *
-     * @param Twig_Environment $environment The current Twig_Environment instance
-     */
-    public function initRuntime(Twig_Environment $environment)
+    public function initRuntime(Environment $environment)
     {
         $baseTemplateClass = $environment->getBaseTemplateClass();
 

--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -67,10 +67,8 @@
         </service>
         <service id="sonata.cache.twig_template_recorder_injector" public="false"
                  class="Sonata\CacheBundle\Cache\TwigTemplateRecorderInjector">
-            <argument type="service" id="twig"/>
+            <tag name="twig.extension"/>
             <argument type="service" id="sonata.cache.recorder"/>
-
-            <tag name="twig.extension" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -65,8 +65,7 @@
         <service id="sonata.cache.invalidation.simple" class="Sonata\CacheBundle\Invalidation\SimpleCacheInvalidation">
             <argument type="service" id="logger"/>
         </service>
-        <service id="sonata.cache.twig_template_recorder_injector" public="false"
-                 class="Sonata\CacheBundle\Cache\TwigTemplateRecorderInjector">
+        <service id="sonata.cache.twig_template_recorder_injector" class="Sonata\CacheBundle\Cache\TwigTemplateRecorderInjector" public="false">
             <tag name="twig.extension"/>
             <argument type="service" id="sonata.cache.recorder"/>
         </service>

--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -65,5 +65,12 @@
         <service id="sonata.cache.invalidation.simple" class="Sonata\CacheBundle\Invalidation\SimpleCacheInvalidation">
             <argument type="service" id="logger"/>
         </service>
+        <service id="sonata.cache.twig_template_recorder_injector" public="false"
+                 class="Sonata\CacheBundle\Cache\TwigTemplateRecorderInjector">
+            <argument type="service" id="twig"/>
+            <argument type="service" id="sonata.cache.recorder"/>
+
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/SonataCacheBundle.php
+++ b/src/SonataCacheBundle.php
@@ -23,19 +23,4 @@ class SonataCacheBundle extends Bundle
 
         $container->addCompilerPass(new CacheCompilerPass());
     }
-
-    public function boot()
-    {
-        if ($this->container->has('twig')) {
-            $baseTemplateClass = $this->container->get('twig')->getBaseTemplateClass();
-
-            if (empty($baseTemplateClass)) {
-                return;
-            }
-
-            if (method_exists($baseTemplateClass, 'attachRecorder')) {
-                call_user_func([$baseTemplateClass, 'attachRecorder'], $this->container->get('sonata.cache.recorder'));
-            }
-        }
-    }
 }


### PR DESCRIPTION
I am targeting this branch, because this backwards-compatible optimization.

## Changelog

```markdown
### Changed
- Twig is no longer initialized on container boot
```

I was originally planning using [service configurator](http://symfony.com/doc/current/service_container/configurators.html) but turns out there can be only one and TwigBundle adds one by default...

~So I resorted to this ugly hack. This should theoretically work and I manually checked the dumped container - but it would be nice if someone tested this with a live app.~

~The only thing I'm not sure about is the order: before we would get a fully-ready twig instance, now it's place in middle of initialization process...~

Found a better approach - but it would be still nice if someone tested this with a live app