### PR TITLE
Fix wrong version of depreaction message

### DIFF
--- a/src/Adapter/SsiCache.php
+++ b/src/Adapter/SsiCache.php
@@ -51,7 +51,7 @@ class SsiCache implements CacheAdapterInterface
     {
         if (interface_exists(ArgumentResolverInterface::class) && !$argumentResolver) {
             @trigger_error(sprintf(
-                'Not providing a "%s" instance to "%s" is deprecated since 3.x and will not be possible in 4.0',
+                'Not providing a "%s" instance to "%s" is deprecated since 2.x and will not be possible in 3.0',
                 ArgumentResolverInterface::class,
                 __METHOD__
             ), E_USER_DEPRECATED);

--- a/src/Adapter/SymfonyCache.php
+++ b/src/Adapter/SymfonyCache.php
@@ -77,7 +77,7 @@ class SymfonyCache implements CacheAdapterInterface
     public function __construct(RouterInterface $router, Filesystem $filesystem, $cacheDir, $token, $phpCodeCacheEnabled, array $types, array $servers, array $timeouts = [])
     {
         if (!$timeouts) {
-            @trigger_error('The "timeouts" argument is available since 3.x and will become mandatory in 4.0, please provide it.', E_USER_DEPRECATED);
+            @trigger_error('The "timeouts" argument is available since 2.x and will become mandatory in 3.0, please provide it.', E_USER_DEPRECATED);
 
             $timeouts = [
                 'RCV' => ['sec' => 2, 'usec' => 0],

--- a/src/Adapter/VarnishCache.php
+++ b/src/Adapter/VarnishCache.php
@@ -83,7 +83,7 @@ class VarnishCache implements CacheAdapterInterface
     ) {
         if (interface_exists(ArgumentResolverInterface::class) && !$argumentResolver) {
             @trigger_error(sprintf(
-                'Not providing a "%s" instance to "%s" is deprecated since 3.x and will not be possible in 4.0',
+                'Not providing a "%s" instance to "%s" is deprecated since 2.x and will not be possible in 3.0',
                 ArgumentResolverInterface::class,
                 __METHOD__
             ), E_USER_DEPRECATED);

--- a/tests/Adapter/SsiCacheTest.php
+++ b/tests/Adapter/SsiCacheTest.php
@@ -122,7 +122,7 @@ class SsiCacheTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Not providing a "Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface" instance to "Sonata\CacheBundle\Adapter\SsiCache::__construct" is deprecated since 3.x and will not be possible in 4.0
+     * @expectedDeprecation Not providing a "Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface" instance to "Sonata\CacheBundle\Adapter\SsiCache::__construct" is deprecated since 2.x and will not be possible in 3.0
      */
     public function testConstructorLegacy()
     {

--- a/tests/Adapter/VarnishCacheTest.php
+++ b/tests/Adapter/VarnishCacheTest.php
@@ -153,7 +153,7 @@ CMD
 
     /**
      * @group legacy
-     * @expectedDeprecation Not providing a "Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface" instance to "Sonata\CacheBundle\Adapter\VarnishCache::__construct" is deprecated since 3.x and will not be possible in 4.0
+     * @expectedDeprecation Not providing a "Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface" instance to "Sonata\CacheBundle\Adapter\VarnishCache::__construct" is deprecated since 2.x and will not be possible in 3.0
      */
     public function testConstructorLegacy()
     {


### PR DESCRIPTION
So CacheBundle is 2.x currenly, not 3.x.