### PR TITLE
use the class from cache component and make service public

### DIFF
--- a/src/Resources/config/phpcr_odm.xml
+++ b/src/Resources/config/phpcr_odm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.cache.phpcr_odm.event_subscriber.default" class="Sonata\CacheBundle\Invalidation\DoctrinePHPCRODMListener">
+        <service id="sonata.cache.phpcr_odm.event_subscriber.default" class="Sonata\Cache\Invalidation\DoctrinePHPCRODMListener" public="true">
             <argument type="service" id="sonata.cache.model_identifier"/>
             <argument/>
         </service>


### PR DESCRIPTION
## Changelog
```markdown
### Fixed
- Wrong namespace for `sonata.cache.phpcr_odm.event_subscriber.default` config
- `sonata.cache.phpcr_odm.event_subscriber.default`is now `public`
```
