### PR TITLE
Fix deprecation for symfony/config 4.2+

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,8 +20,14 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('sonata_cache')->children();
+        $treeBuilder = new TreeBuilder('sonata_cache');
+
+        // Keep compatibility with symfony/config < 4.2
+        if (!\method_exists($treeBuilder, 'getRootNode')) {
+            $node = $treeBuilder->root('sonata_cache')->children();
+        } else {
+            $node = $treeBuilder->getRootNode()->children();
+        }
 
         $node
             ->arrayNode('cache_invalidation')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is to fix [deprecation for symfony/config 4.2+](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes) as in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/871
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because is the one with this warning.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix deprecation for symfony/config 4.2+
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->