### PR TITLE
Commands as services

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,2 +1,9 @@
 UPGRADE 3.x
 ===========
+
+## Deprecated commands that get the cache manager from the container
+
+Any command that extends `Sonata\CacheBundle\Command\BaseCacheCommand` should
+provide the `Sonata\Cache\CacheManagerInterface` as a first argument to the
+parent class. This should be done automatically in applications that have
+autowiring enabled for such commands.

--- a/src/Command/BaseCacheCommand.php
+++ b/src/Command/BaseCacheCommand.php
@@ -20,6 +20,6 @@ abstract class BaseCacheCommand extends ContainerAwareCommand
 {
     public function getManager(): CacheManagerInterface
     {
-        return $this->getContainer()->get('sonata.cache.manager');
+        return $this->getContainer()->get(CacheManagerInterface::class);
     }
 }

--- a/src/Command/BaseCacheCommand.php
+++ b/src/Command/BaseCacheCommand.php
@@ -16,10 +16,36 @@ namespace Sonata\CacheBundle\Command;
 use Sonata\Cache\CacheManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
+/**
+ * NEXT_MAJOR: stop extending ContainerAwareCommand.
+ */
 abstract class BaseCacheCommand extends ContainerAwareCommand
 {
+    /**
+     * @var ?CacheManagerInterface
+     */
+    private $cacheManager;
+
+    public function __construct(
+        string $name = null,
+        CacheManagerInterface $cacheManager = null
+    ) {
+        parent::__construct($name);
+        if (null === $cacheManager) {
+            @trigger_error(sprintf(
+                'Not providing a cache manager to "%s" is deprecated since 3.x and will no longer be possible in 4.0',
+                \get_class($this)
+            ), E_USER_DEPRECATED);
+        }
+        $this->cacheManager = $cacheManager;
+    }
+
     public function getManager(): CacheManagerInterface
     {
-        return $this->getContainer()->get(CacheManagerInterface::class);
+        if (null === $this->cacheManager) {
+            return $this->getContainer()->get(CacheManagerInterface::class);
+        }
+
+        return $this->cacheManager;
     }
 }

--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -66,5 +66,15 @@
         <service id="sonata.cache.invalidation.simple" class="Sonata\Cache\Invalidation\SimpleCacheInvalidation">
             <argument type="service" id="logger"/>
         </service>
+        <service id="sonata.cache.command.flush" class="Sonata\CacheBundle\Command\CacheFlushCommand">
+            <argument type="constant">null</argument>
+            <argument type="service" id="sonata.cache.manager"/>
+            <tag name="console.command"/>
+        </service>
+        <service id="sonata.cache.command.flushall" class="Sonata\CacheBundle\Command\CacheFlushAllCommand">
+            <argument type="constant">null</argument>
+            <argument type="service" id="sonata.cache.manager"/>
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="Sonata\Cache\CacheManagerInterface" alias="sonata.cache.manager"/>
         <service id="sonata.cache.manager" class="Sonata\Cache\CacheManager">
             <argument/>
             <argument/>


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is BC.

Commands in this project still access services directly through the container.
This PR tries to get them with DI, and falls back on accessing them through an interface, while deprecating doing so.


Fixes #250

## Changelog

```markdown
### Fixed
- crash when running `sonata:cache:flush-all` or `sonata:cache:flush`

### Deprecated
- not providing a cache manager to commands extending `Sonata\CacheBundle\Command\BaseCacheCommand`
```

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/SonataCacheBundle
composer require sonata-project/cache-bundle "dev-commands-as-services as 3.0.1"
```

