### PR TITLE
fix(symfony cache): fix error raised by listeners on symfony cache clear

### DIFF
--- a/src/Command/CacheFlushAllCommand.php
+++ b/src/Command/CacheFlushAllCommand.php
@@ -16,6 +16,7 @@ namespace Sonata\CacheBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class CacheFlushAllCommand extends BaseCacheCommand
 {
@@ -49,6 +50,9 @@ class CacheFlushAllCommand extends BaseCacheCommand
                 $output->writeln('<error>Failed!</error>');
             }
         }
+
+        // The current event dispatcher is stale, let's not use it anymore
+        $this->getApplication()->setDispatcher(new EventDispatcher());
 
         $output->writeln('<info>Done!</info>');
     }

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -16,6 +16,7 @@ namespace Sonata\CacheBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class CacheFlushCommand extends BaseCacheCommand
 {
@@ -57,6 +58,11 @@ class CacheFlushCommand extends BaseCacheCommand
             $output->write(sprintf(' > %s : starting .... ', $name));
             $cache->flush($keys);
             $output->writeln('Ok');
+        }
+
+        if ($input->getOption('cache') && \in_array('sonata.cache.symfony', $input->getOption('cache'), true)) {
+            // The current event dispatcher is stale, let's not use it anymore
+            $this->getApplication()->setDispatcher(new EventDispatcher());
         }
 
         $output->writeln('<info>Done!</info>');

--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -54,6 +54,7 @@
         </service>
         <service id="sonata.cache.symfony" class="Sonata\CacheBundle\Adapter\SymfonyCache">
             <tag name="sonata.cache"/>
+            <tag name="controller.service_arguments"/>
             <argument type="service" id="router"/>
             <argument type="service" id="filesystem"/>
             <argument type="string">%kernel.cache_dir%</argument>
@@ -62,6 +63,7 @@
             <argument/>
             <argument type="collection"/>
             <argument/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
         <service id="sonata.cache.invalidation.simple" class="Sonata\Cache\Invalidation\SimpleCacheInvalidation">
             <argument type="service" id="logger"/>


### PR DESCRIPTION
## Subject

I am targeting this branch, because it does not introduce a BC break.

Clearing the symfony cache with command (and then by http request through socket) requires to set the event dispatcher stateless to avoid further events to be called/executed without cache, which currently raises an error (even if the cache is well cleared).

Executing flush command leads to:
```
~/html/test $ bin/console sonata:cache:flush-all --env=prod
[2019-04-30 19:38:32] Executing command bin/console 'sonata:cache:flush-all' --env=prod

clearing cache information
 > sonata.page.cache.js_sync : starting .... OK
 > sonata.page.cache.js_async : starting .... OK
 > sonata.cache.noop : starting .... OK
 > sonata.cache.predis : starting .... OK
 > sonata.cache.symfony : starting .... FAILED!
done!

Warning: require(/var/www/html/test/var/cache/prod/ContainerYiibwfd/getSwiftmailer_EmailSender_ListenerService.php): failed to open stream: No such file or directory in /var/www/html/test/var/cache/prod/ContainerYiibwfd/appProdProjectContainer.php on line 3055

Fatal error: require(): Failed opening required '/var/www/html/test/var/cache/prod/ContainerYiibwfd/getSwiftmailer_EmailSender_ListenerService.php' (include_path='.:/usr/local/lib/php') in /var/www/html/test/var/cache/prod/ContainerYiibwfd/appProdProjectContainer.php on line 3055

In appProdProjectContainer.php line 3055:

  Compile Error: require(): Failed opening required '/var/www/html/test/var/cache/prod/ContainerYiibwfd/getSwiftmailer_Email
  Sender_ListenerService.php' (include_path='.:/usr/local/lib/php')
```
The cache is well cleared but command return code isn't valid.

So what is done here is similar to https://github.com/symfony/symfony/blob/1f388aee46e82ca0beb56943c596aba6b4b28a72/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L95 from clear cache command of Symfony itself for both commands `flush` & `flush-all`

For the symfony cache action in `Adapter\SymfonyCache`, it requires to empty the listener list of event dispatcher which is harmless at this point as the cache is cleared just after. This is why we need to inject the `event_dispatcher`.

## Changelog

```markdown
### Fixed
Fix return code of flush command for symfony cache
```