### PR TITLE
Add argument_resolver service to SSI and ESI cache

### DIFF
--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -45,12 +45,14 @@
             <argument type="service" id="router"/>
             <argument/>
             <argument type="service" id="controller_resolver"/>
+            <argument type="service" id="argument_resolver"/>
         </service>
         <service id="sonata.cache.ssi" class="Sonata\CacheBundle\Adapter\SsiCache">
             <tag name="sonata.cache"/>
             <argument/>
             <argument type="service" id="router"/>
             <argument type="service" id="controller_resolver"/>
+            <argument type="service" id="argument_resolver"/>
         </service>
         <service id="sonata.cache.symfony" class="Sonata\CacheBundle\Adapter\SymfonyCache">
             <tag name="sonata.cache"/>


### PR DESCRIPTION
## Subject

The ESI and SSI cache requires an extra parameter for the `argument_resolver` service which is not currently defined in the service definition

I am targeting this branch, because it is a bug fix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - missing argument for SSI and ESI cache
```