### PR TITLE
Allow Symfony 5 in composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,16 @@ matrix:
     - php: '7.2'
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: '7.3'
-      env: SYMFONY=3.4.*
+      env: SYMFONY=4.3.*
     - php: '7.3'
-      env: SYMFONY='dev-master as 3.4.x-dev'
+      env: SYMFONY='dev-master as 4.3.x-dev'
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
     - php: 7.4snapshot
     - php: nightly
     - env: SYMFONY_DEPRECATIONS_HELPER=0
-    - env: SYMFONY='dev-master as 3.4.x-dev'
+    - env: SYMFONY='dev-master as 4.3.x-dev'
 
 before_install:
   - git remote add upstream ${UPSTREAM_URL} && git fetch --all

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     "require": {
         "php": "^7.1",
         "sonata-project/cache": "^2.0.0",
-        "symfony/config": "^3.4 || ^4.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0",
-        "symfony/filesystem": "^3.4 || ^4.0",
-        "symfony/http-foundation": "^3.4.35 || ^4.0",
-        "symfony/http-kernel": "^3.4 || ^4.0",
+        "symfony/config": "^3.4 || ^4.0 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
+        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
+        "symfony/http-foundation": "^3.4.35 || ^4.0 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0",
         "symfony/process": "^3.4 || ^4.0",
-        "symfony/routing": "^3.4 || ^4.0"
+        "symfony/routing": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
@@ -36,8 +36,8 @@
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "php-mock/php-mock": "^2.0",
         "predis/predis": "^1.0",
-        "symfony/console": "^3.4 || ^4.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0",
+        "symfony/console": "^3.4 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^4.1"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     "require": {
         "php": "^7.1",
         "sonata-project/cache": "^2.0.0",
-        "symfony/config": "^3.4 || ^4.0 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
-        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
-        "symfony/http-foundation": "^3.4.35 || ^4.0 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0",
+        "symfony/config": "^4.3 || ^5.0",
+        "symfony/dependency-injection": "^4.3 || ^5.0",
+        "symfony/filesystem": "^4.3 || ^5.0",
+        "symfony/http-foundation": "^4.3 || ^5.0",
+        "symfony/http-kernel": "^4.3 || ^5.0",
         "symfony/process": "^3.4 || ^4.0",
-        "symfony/routing": "^3.4 || ^4.0 || ^5.0"
+        "symfony/routing": "^4.3 || ^5.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
@@ -36,8 +36,8 @@
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "php-mock/php-mock": "^2.0",
         "predis/predis": "^1.0",
-        "symfony/console": "^3.4 || ^4.0 || ^5.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
+        "symfony/console": "^4.3 || ^5.0",
+        "symfony/framework-bundle": "^4.3 || ^5.0",
         "symfony/phpunit-bridge": "^4.1"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/config": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "symfony/filesystem": "^4.3 || ^5.0",
-        "symfony/http-foundation": "^4.3 || ^5.0",
+        "symfony/http-foundation": "^4.3.4 || ^5.0",
         "symfony/http-kernel": "^4.3 || ^5.0",
         "symfony/process": "^3.4 || ^4.0",
         "symfony/routing": "^4.3 || ^5.0"

--- a/src/Command/CacheFlushAllCommand.php
+++ b/src/Command/CacheFlushAllCommand.php
@@ -55,5 +55,7 @@ class CacheFlushAllCommand extends BaseCacheCommand
         $this->getApplication()->setDispatcher(new EventDispatcher());
 
         $output->writeln('<info>Done!</info>');
+
+        return 0;
     }
 }

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -66,5 +66,7 @@ class CacheFlushCommand extends BaseCacheCommand
         }
 
         $output->writeln('<info>Done!</info>');
+
+        return 0;
     }
 }

--- a/tests/Adapter/SymfonyCacheTest.php
+++ b/tests/Adapter/SymfonyCacheTest.php
@@ -117,7 +117,7 @@ class SymfonyCacheTest extends TestCase
         $this->assertSame(200, $response->getStatusCode(), 'Response should be 200');
         $this->assertSame('ok', $response->getContent(), 'Response should return "OK"');
 
-        $this->assertEquals(2, $response->headers->get('Content-Length'));
+        $this->assertSame('2', $response->headers->get('Content-Length'));
         $this->assertSame('must-revalidate, no-cache, private', $response->headers->get('Cache-Control'));
     }
 

--- a/tests/Adapter/SymfonyCacheTest.php
+++ b/tests/Adapter/SymfonyCacheTest.php
@@ -117,7 +117,7 @@ class SymfonyCacheTest extends TestCase
         $this->assertSame(200, $response->getStatusCode(), 'Response should be 200');
         $this->assertSame('ok', $response->getContent(), 'Response should return "OK"');
 
-        $this->assertSame('2', $response->headers->get('Content-Length'));
+        $this->assertEquals(2, $response->headers->get('Content-Length'));
         $this->assertSame('must-revalidate, no-cache, private', $response->headers->get('Cache-Control'));
     }
 


### PR DESCRIPTION
## Subject

Allow Symfony 5 components in composer.json

I am targeting this branch because it is backwards compatible.

## Changelog


```markdown
### Added
- Added symfony 5 components in composer.json

## Removed
- Removed support for symfony 3

```