### PR TITLE
Change void return declarations commands to be integer returns

### DIFF
--- a/src/Command/CacheFlushAllCommand.php
+++ b/src/Command/CacheFlushAllCommand.php
@@ -33,7 +33,7 @@ class CacheFlushAllCommand extends BaseCacheCommand
         );
     }
 
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('<info>Clearing cache information.</info>');
 

--- a/src/Command/CacheFlushCommand.php
+++ b/src/Command/CacheFlushCommand.php
@@ -42,7 +42,7 @@ class CacheFlushCommand extends BaseCacheCommand
     /**
      * @throws \RuntimeException
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $keys = @json_decode($input->getOption('keys'), true);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Integer return in CacheFlushCommand would throw a compile error

<!-- Describe your Pull Request content here -->
When installing SonataCacheBundle using PHP version 7.4.1 a compile error is thrown because the `execute` method in the CacheFlushCommand is a void method but returns a 0 if it is run successfully. Symfony requires a proper exit code to be set so an integer should always be returned when calling these methods.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCacheBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->
### Fixed
- Removed `void` return type declarations from the command execute methods
- Added `int` return type declarations to the command execute methods

