### PR TITLE
fix(command): remove null arg to match code

### DIFF
--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -71,14 +71,12 @@
             <argument type="service" id="logger"/>
         </service>
         <service id="sonata.cache.command.flush" class="Sonata\CacheBundle\Command\CacheFlushCommand">
-            <argument type="constant">null</argument>
-            <argument type="service" id="sonata.cache.manager"/>
             <tag name="console.command"/>
+            <argument type="service" id="sonata.cache.manager"/>
         </service>
         <service id="sonata.cache.command.flushall" class="Sonata\CacheBundle\Command\CacheFlushAllCommand">
-            <argument type="constant">null</argument>
-            <argument type="service" id="sonata.cache.manager"/>
             <tag name="console.command"/>
+            <argument type="service" id="sonata.cache.manager"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Fix DI after https://github.com/sonata-project/SonataCacheBundle/pull/384/files#diff-790d1f4f59b76f2a16b8119eac862585dbf4b38de091ebcae1bda6226f200e6bR26-R29

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCacheBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bug fix.
Bug fix dependency injection for commands

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCacheBundle/releases,
    please keep it short and clear and to the point
-->


<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Dependency injection for commands
```
